### PR TITLE
Scheme agnostic api url

### DIFF
--- a/arborcat_lists/src/Controller/DefaultController.php
+++ b/arborcat_lists/src/Controller/DefaultController.php
@@ -71,9 +71,9 @@ class DefaultController extends ControllerBase {
 
       foreach ($items as $item) {
         // grab bib record
-        $json = $guzzle->get("http://$api_url/record/$item->bib")->getBody()->getContents();
+        $json = $guzzle->get("$api_url/record/$item->bib")->getBody()->getContents();
         $bib_record = json_decode($json);
-        $mat_types = $guzzle->get("http://$api_url/mat-names")->getBody()->getContents();
+        $mat_types = $guzzle->get("$api_url/mat-names")->getBody()->getContents();
         $mat_name = json_decode($mat_types);
         $bib_record->mat_name = $mat_name->{$bib_record->mat_code};
         $list_items['items'][$item->item_id] = $bib_record;

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -28,10 +28,10 @@ class DefaultController extends ControllerBase {
 
     // Get Bib Record from API
     $guzzle = \Drupal::httpClient();
-    $json = $guzzle->get("http://$api_url/record/$bnum")->getBody()->getContents();
+    $json = $guzzle->get("$api_url/record/$bnum")->getBody()->getContents();
     $bib_record = json_decode($json);
 
-    $mat_types = $guzzle->get("http://$api_url/mat-names")->getBody()->getContents();
+    $mat_types = $guzzle->get("$api_url/mat-names")->getBody()->getContents();
     $mat_name = json_decode($mat_types);
     $bib_record->mat_name = $mat_name->{$bib_record->mat_code};
 

--- a/src/Form/ArborcatAdminForm.php
+++ b/src/Form/ArborcatAdminForm.php
@@ -53,7 +53,7 @@ class ArborcatAdminForm extends ConfigFormBase {
       '#default_value' => \Drupal::config('arborcat.settings')->get('api_url'),
       '#size' => 32,
       '#maxlength' => 64,
-      '#description' => t('URL of the API server for Arborcat. (e.g. api.website.org)'),
+      '#description' => t('URL of the API server for Arborcat. (e.g. https://api.website.org)'),
     ];
 
     return parent::buildForm($form, $form_state);

--- a/src/Form/ArborcatBarcodeForm.php
+++ b/src/Form/ArborcatBarcodeForm.php
@@ -99,7 +99,7 @@ class ArborcatBarcodeForm extends FormBase {
         $query['phone'] = $form_state->getValue('phone');
       }
 
-      $response = $guzzle->request('GET', "http://$api_url/patron/validate_barcode", ['query' => $query]);
+      $response = $guzzle->request('GET', "$api_url/patron/validate_barcode", ['query' => $query]);
       $response_body = json_decode($response->getBody()->getContents());
 
       if ($response_body->status == 'ERROR') {

--- a/src/Plugin/Block/CheckoutsBlock.php
+++ b/src/Plugin/Block/CheckoutsBlock.php
@@ -25,7 +25,7 @@ class CheckoutsBlock extends BlockBase {
 
     // Get Checkouts from API
     $guzzle = \Drupal::httpClient();
-    $json = $guzzle->get("http://$api_url/patron/$api_key/checkouts")->getBody()->getContents();
+    $json = $guzzle->get("$api_url/patron/$api_key/checkouts")->getBody()->getContents();
     $checkouts = json_decode($json);
 
     $output = '<h2>Checkouts</h2>';

--- a/src/Plugin/Block/HoldsBlock.php
+++ b/src/Plugin/Block/HoldsBlock.php
@@ -25,9 +25,9 @@ class HoldsBlock extends BlockBase {
 
     // Get holds from API
     $guzzle = \Drupal::httpClient();
-    $json = $guzzle->get("http://$api_url/patron/$api_key/holds")->getBody()->getContents();
+    $json = $guzzle->get("$api_url/patron/$api_key/holds")->getBody()->getContents();
     $holds = json_decode($json);
-    $locations = json_decode($guzzle->get("http://$api_url/locations")->getBody()->getContents());
+    $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
 
     $output = '<h2>Requests</h2>';
     if (count($holds)) {

--- a/src/Plugin/Block/PatronBlock.php
+++ b/src/Plugin/Block/PatronBlock.php
@@ -25,8 +25,8 @@ class PatronBlock extends BlockBase {
 
     // Get patron info from API
     $guzzle = \Drupal::httpClient();
-    $patron = json_decode($guzzle->get("http://$api_url/patron/$api_key/get")->getBody()->getContents());
-    $fines = json_decode($guzzle->get("http://$api_url/patron/$api_key/fines")->getBody()->getContents());
+    $patron = json_decode($guzzle->get("$api_url/patron/$api_key/get")->getBody()->getContents());
+    $fines = json_decode($guzzle->get("$api_url/patron/$api_key/fines")->getBody()->getContents());
 
     $output = '<h2>Account Summary</h2>';
     $output .= "<img id=\"bcode-img\" class=\"no-tabdesk-display\" src=\"http://laluba.aadl.org/bcode.php?input=$patron->card\" alt=\"Image of barcode for scanning at selfchecks\">"; 


### PR DESCRIPTION
Might be another preferred way of doing this but the API URL scheme should be configurable so we can use SSL or just HTTP depending on needs.

In all likelihood, we will want everything SSL that handles patron data so just getting this done now.