### PR TITLE
Add div for barcode form

### DIFF
--- a/src/Form/ArborcatBarcodeForm.php
+++ b/src/Form/ArborcatBarcodeForm.php
@@ -36,6 +36,10 @@ class ArborcatBarcodeForm extends FormBase {
       '#maxlength' => 32,
       '#description' => t('Your Library Card Barcode number for user ' . $uid),
     ];
+    $form['patron_data'] = [
+      '#prefix' => '<div id="barcode-form-patron-data"><h3>Validate Barcode with ONE of the following items</h3>',
+      '#suffix' => '</div>',
+    ];
     $form['patron_data']['name'] = [
       '#type' => 'textfield',
       '#title' => t('Last Name'),


### PR DESCRIPTION
Ideally, barcode-form-patron-data would float to the right of the Barcode field, and make it more obvious that you only need to enter one of the three items. 