### PR TITLE
Patron role

### DIFF
--- a/config/install/user.role.patron.yml
+++ b/config/install/user.role.patron.yml
@@ -1,0 +1,8 @@
+dependencies: {  }
+id: patron
+is_admin: false
+label: Patron
+langcode: en
+permissions: {  }
+status: true
+weight: 3

--- a/src/Plugin/Block/PatronBlock.php
+++ b/src/Plugin/Block/PatronBlock.php
@@ -42,7 +42,8 @@ class PatronBlock extends BlockBase {
     $uid = $user->get('uid')->value;
     $email = $user->get('mail')->value;
     $payment_link = ($fines->total ? ' (<a href="/fees-payment">pay fees</a>)' : '');
-
+    $card_is_current = $this->currentPatron($user, $patron->expires);
+    
     $output = '<h2 id="account-sum" class="no-margin">Account Summary</h2>';
     $output .= "<img id=\"bcode-img\" src=\"$api_url/patron/$api_key/barcode\" alt=\"Image of barcode for scanning at selfchecks\">";
     $output .= '<table class="account-summary" class="l-overflow-clear"><tbody>';
@@ -79,5 +80,18 @@ class PatronBlock extends BlockBase {
   public function access(AccountInterface $account, $return_as_object = FALSE) {
     $route_name = \Drupal::routeMatch()->getRouteName();
     return ($route_name == 'entity.user.canonical' ? AccessResult::allowed() : AccessResult::forbidden());
+  }
+
+  public function currentPatron($user, $expiration)
+  {
+    if (strtotime($expiration) >= time()) {
+      $user->addRole('patron');
+      $user->save();
+      return true;
+    } else {
+      $user->removeRole('patron');
+      $user->save();
+      return false;
+    }
   }
 }


### PR DESCRIPTION
This adds a patron role and checks whether it should be added or removed based on the card status on every block render. 

I didn't dig through the code but presume this block is only really rendered if a card is attached.

This allows a few things:
- We can assign permissions to this role in other modules and don't have to make api calls
- Modules or templates can just check if user has that role in addition to permissions

Note: I made an install script without dependencies. We can add arborcat as a dependency and then the role is removed when arborcat is but presumed this was safer. We'll need to create the role on already installed sites I think.

I return a boolean so we can tweak this block later to give an alert of expiration, etc. Could probably throw a message in the function instead.

If someone can try this out in their dev environment that would be great for sanity. I don't think the user saving should interfere with anything else on that page.
