### PR TITLE
Pickup requests expanded locker validation

### DIFF
--- a/arborcat.libraries.yml
+++ b/arborcat.libraries.yml
@@ -2,3 +2,6 @@ pickuprequest-functions:
   version: 1.x
   js:
     js/pickuprequest-functions.js: {}
+  dependencies:
+    - core/drupalSettings
+

--- a/arborcat.module
+++ b/arborcat.module
@@ -153,9 +153,10 @@ function arborcat_patron_fines_expired($fines, $patron)
   function arborcat_pickup_locations($destLocation = null)
   {
       $db = \Drupal::database();
-      $query = $db->select('arborcat_pickup_location', 'apl');
-      $query->fields('apl', ['locationId', 'branchLocationId', 'timePeriod', 'timePeriodStart', 'timePeriodEnd', 'maxLockers', 'locationName', 'locationDescription']);
-        
+      $query = $db->select('arborcat_pickup_location', 'apl')
+        ->fields('apl', ['locationId', 'branchLocationId', 'timePeriod', 'timePeriodStart', 'timePeriodEnd', 'maxLockers', 'locationName', 'locationDescription'])
+        ->condition('active', 1, "=");
+
       // add in a condition if a location is supplied to filter on
       if (3 == strlen($destLocation)) {
           $query->condition('apl.branchLocationId', (int) $destLocation, '=');
@@ -165,6 +166,22 @@ function arborcat_patron_fines_expired($fines, $patron)
       $pickupLocationRecords = $result->fetchAll();
       return $pickupLocationRecords;
   }
+
+  /*
+   * returns an array of active locker pickup locations.
+   */
+  function arborcat_lockerPickupLocations() {
+    $locations = [];
+    $db = \Drupal::database();
+    $query = $db->select('arborcat_pickup_location', 'apl')
+        ->fields('apl', ['locationId'])
+        ->condition('maxLockers', 0, '>')
+        ->condition('active', 1, '=')
+        ->execute();
+    $locations = array_values($query->fetchCol());
+    return $locations;
+  }
+
 
    /*
    * Checks the availability of a locker fo the specified date and timePeriod.
@@ -257,4 +274,19 @@ function arborcat_patron_fines_expired($fines, $patron)
     $scheduled_pickups = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/scheduled-pickups")->getBody()->getContents(), true);
 
     return $scheduled_pickups;
+  }
+
+  /*
+    * Debugging routine to log to the <root folder>/LWKLWK.log
+    */
+  function dblog(...$thingsToLog) {
+      $lineToLog = '';
+      foreach ($thingsToLog as $item) {
+          $lineToLog = $lineToLog . ' ' . print_r($item, true);
+      }
+      // prepend date/time onto log line
+      $nowDateTime = new DrupalDateTime();
+      $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
+      $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
+      error_log($completeLine, 3, "LWKLWK.log");
   }

--- a/arborcat.module
+++ b/arborcat.module
@@ -279,18 +279,3 @@ function arborcat_patron_fines_expired($fines, $patron)
 
     return $scheduled_pickups;
   }
-
-  /*
-    * Debugging routine to log to the <root folder>/LWKLWK.log
-    */
-  function dblog(...$thingsToLog) {
-      $lineToLog = '';
-      foreach ($thingsToLog as $item) {
-          $lineToLog = $lineToLog . ' ' . print_r($item, true);
-      }
-      // prepend date/time onto log line
-      $nowDateTime = new DrupalDateTime();
-      $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
-      $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
-      error_log($completeLine, 3, "LWKLWK.log");
-  }

--- a/arborcat.module
+++ b/arborcat.module
@@ -67,6 +67,16 @@ function arborcat_theme($existing, $type, $theme, $path) {
   ];
 }
 
+/**
+ * @param $variables
+ */
+function arborcat_preprocess_page(&$variables)
+{
+    // get the max locker item check  from ArborCat module settings
+    $max_locker_items = \Drupal::config('arborcat.settings')->get('max_locker_items_check');
+    $variables['#attached']['drupalSettings']['arborcat']['max_locker_items_check'] = $max_locker_items;
+}
+
 function arborcat_generate_api_key() {
   // Use the UUID service to generate a Unique identifier
   $uuid_service = \Drupal::service('uuid');
@@ -248,7 +258,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
                               'Status' => $hold['status'],
                               'PickupLoc' => $hold['pickup'],
                               'pickup_lib' => $hold['hold']['pickup_lib'],
-                              'holdId' => $hold['id'], f
+                              'holdId' => $hold['id'],
                               'usr' => $hold['hold']['usr']
                           ];
                         $i++;

--- a/arborcat.module
+++ b/arborcat.module
@@ -6,171 +6,164 @@ use Drupal\Core\Datetime\DrupalDateTime;
  * Display help and module information
  * @return help text for section
  */
-function arborcat_help($path, $arg)
-{
-    $output = '';
+function arborcat_help($path, $arg) {
+  $output = '';
 
-    switch ($path) {
-    case "admin/help#arborcat":
-      $output = '<p>' .  t("Catalog functions for Evergreen") . '</p>';
-      break;
+  switch ($path) {
+  case "admin/help#arborcat":
+    $output = '<p>' .  t("Catalog functions for Evergreen") . '</p>';
+    break;
   }
 
-    return $output;
+  return $output;
 }
 
-function arborcat_theme($existing, $type, $theme, $path)
-{
-    return [
+function arborcat_theme($existing, $type, $theme, $path) {
+  return [
     'catalog' => [
       'variables' => [
-        'catalog_slider' => null,
-        'community_slider' => null,
-        'podcast_slider' => null
+        'catalog_slider' => NULL,
+        'community_slider' => NULL,
+        'podcast_slider' => NULL
       ]
     ],
     'catalog_record' => [
       'variables' => [
-        'record' => null,
-        'api_key' => null,
-        'lists' => null,
-        'reviews' => null,
-        'review_form' => null,
-        'ratings' => null
+        'record' => NULL,
+        'api_key' => NULL,
+        'lists' => NULL,
+        'reviews' => NULL,
+        'review_form' => NULL,
+        'ratings' => NULL
       ]
     ],
     'moderate_reviews' => [
       'variables' => [
-        'reviews' => null,
-        'pager' => null
+        'reviews' => NULL,
+        'pager' => NULL
       ]
     ],
     'pickup_request_form' => [
       'variables' => [
-          'formhtml' => null,
+          'formhtml' => NULL,
       ]
     ],
     'patron_request_ready_locations_lookup_theme' => [
        'variables' => [
-        'search_form' => null,
-        'result_form' => null,
-        'item' => null,
-        'branches' =>null
+        'search_form' => NULL,
+        'result_form' => NULL,
+        'item' => NULL,
+        'branches' =>NULL
       ]
     ],
    'patron_requests_ready_locations_theme' => [
       'variables' => [
-        'search_form' => null,
-        'location_urls' => null,
-        'barcode' => null,
-        'scheduled_pickups' => null
+        'search_form' => NULL,
+        'location_urls' => NULL,
+        'barcode' => NULL,
+        'scheduled_pickups' => NULL
       ]
     ],
   ];
 }
 
-function arborcat_generate_api_key()
-{
-    // Use the UUID service to generate a Unique identifier
-    $uuid_service = \Drupal::service('uuid');
-    return $uuid_service->generate();
+function arborcat_generate_api_key() {
+  // Use the UUID service to generate a Unique identifier
+  $uuid_service = \Drupal::service('uuid');
+  return $uuid_service->generate();
 }
 
 // set drupal messages for fees or expired card
-function arborcat_patron_fines_expired($fines, $patron)
-{
-    $patron_clean = true;
+function arborcat_patron_fines_expired($fines, $patron) {
+  $patron_clean = TRUE;
 
-    if ($fines->total > 25) {
-        drupal_set_message("We're sorry, but your account balance is over $25. You won't be able to renew or request items.", 'error');
-        $patron_clean = false;
-    }
-    if (strtotime($patron->expires) < time()) {
-        drupal_set_message("We're sorry, but your card has expired! You can renew in person at any AADL Location.", 'error');
-        $patron_clean = false;
-    }
+  if ($fines->total > 25) {
+      drupal_set_message("We're sorry, but your account balance is over $25. You won't be able to renew or request items.", 'error');
+      $patron_clean = FALSE;
+  }
+  if (strtotime($patron->expires) < time()) {
+      drupal_set_message("We're sorry, but your card has expired! You can renew in person at any AADL Location.", 'error');
+      $patron_clean = FALSE;
+  }
 
-    return $patron_clean;
+  return $patron_clean;
 }
 
 //check if a hold is eligible for a locker based on material type
-  function arborcat_eligible_for_locker($hold)
-  {
-      if ($hold['material'] == "Art Print" || $hold['material'] == "Tools" || $hold['material'] == "Oversize") {
-          return false;
-      } else {
-          return true;
-      }
+  function arborcat_eligible_for_locker($hold) {
+    if ($hold['material'] == "Art Print" || $hold['material'] == "Tools" || $hold['material'] == "Oversize") {
+        return FALSE;
+    } else {
+        return TRUE;
+    }
   }
 
   //check if there are lockers available to place holds into
-  function arborcat_lockers_available($branch)
-  {
-      $mess = \Drupal::messenger();
-      $available=false;
-      if (stripos($branch, 'Malletts')!==false) {
-          $locker_server = 'mcblockers';
-      } elseif (stripos($branch, 'Pittsfield')!==false) {
-          $locker_server = 'ptslockers';
-      }
-      if ($locker_server=='ptslockers') {
-          $ch = curl_init();
-          curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('pts_lockers'));
-          curl_setopt($ch, CURLOPT_HEADER, 0);
-          curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-          curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
-          $result = curl_exec($ch);
+  function arborcat_lockers_available($branch) {
+    $mess = \Drupal::messenger();
+    $available=FALSE;
+    if (stripos($branch, 'Malletts')!==FALSE) {
+        $locker_server = 'mcblockers';
+    } elseif (stripos($branch, 'Pittsfield')!==FALSE) {
+        $locker_server = 'ptslockers';
+    }
+    if ($locker_server=='ptslockers') {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('pts_lockers'));
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
+        $result = curl_exec($ch);
 
-          $simpleXML = simplexml_load_string($result);
-          $i=1;
-          $s = $simpleXML->doors->children();
-          if ($s->assign1==0&$s->assign2==0&$s->assign3==0&$s->assign4==0) {
-              $available=false;
-          } elseif ($s->assign1!==0||$s->assign2!==0||$s->assign3!==0||$s->assign4!==0) {
-              $available=true;
-          }
-      } elseif ($locker_server=='mcblockers') {
-          $ch = curl_init();
-          curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('mcb_lockers'));
-          curl_setopt($ch, CURLOPT_HEADER, 0);
-          curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-          curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
-          $result = curl_exec($ch);
-          if ($result != null) {
-              preg_match_all('%name="web_patroninserted_door.*?value="([\d]+?)"%s', $result, $matches);
-              if ($matches[1][0]>0) {
-                  $available = true;
-              }
-          }
-      }
-      return $available;
+        $simpleXML = simplexml_load_string($result);
+        $i=1;
+        $s = $simpleXML->doors->children();
+        if ($s->assign1==0&$s->assign2==0&$s->assign3==0&$s->assign4==0) {
+            $available = FALSE;
+        } elseif ($s->assign1!==0||$s->assign2!==0||$s->assign3!==0||$s->assign4!==0) {
+            $available = TRUE;
+        }
+    } elseif ($locker_server=='mcblockers') {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('mcb_lockers'));
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
+        $result = curl_exec($ch);
+        if ($result != NULL) {
+            preg_match_all('%name="web_patroninserted_door.*?value="([\d]+?)"%s', $result, $matches);
+            if ($matches[1][0]>0) {
+                $available = TRUE;
+            }
+        }
+    }
+    return $available;
   }
 
   /*
    * returns a list of request pickup locations.
    * If a branch location is passed in, that a filtered list of pickup locations is returned
    */
-  function arborcat_pickup_locations($destLocation = null)
-  {
-      $db = \Drupal::database();
-      $query = $db->select('arborcat_pickup_location', 'apl')
-        ->fields('apl', ['locationId', 'branchLocationId', 'timePeriod', 'timePeriodStart', 'timePeriodEnd', 'maxLockers', 'locationName', 'locationDescription'])
-        ->condition('active', 1, "=");
+  function arborcat_pickup_locations($destLocation = NULL){
+    $db = \Drupal::database();
+    $query = $db->select('arborcat_pickup_location', 'apl')
+      ->fields('apl', ['locationId', 'branchLocationId', 'timePeriod', 'timePeriodStart', 'timePeriodEnd', 'maxLockers', 'locationName', 'locationDescription'])
+      ->condition('active', 1, "=");
 
-      // add in a condition if a location is supplied to filter on
-      if (3 == strlen($destLocation)) {
-          $query->condition('apl.branchLocationId', (int) $destLocation, '=');
-      }
-      $result = $query->execute();
-      
-      $pickupLocationRecords = $result->fetchAll();
-      return $pickupLocationRecords;
+    // add in a condition if a location is supplied to filter on
+    if (3 == strlen($destLocation)) {
+        $query->condition('apl.branchLocationId', (int) $destLocation, '=');
+    }
+    $result = $query->execute();
+    
+    $pickupLocationRecords = $result->fetchAll();
+    return $pickupLocationRecords;
   }
 
   /*
    * returns an array of active locker pickup locations.
    */
-  function arborcat_lockerPickupLocations() {
+  function arborcat_locker_pickup_locations() {
     $locations = [];
     $db = \Drupal::database();
     $query = $db->select('arborcat_pickup_location', 'apl')
@@ -187,86 +180,84 @@ function arborcat_patron_fines_expired($fines, $patron)
    * Checks the availability of a locker fo the specified date and timePeriod.
    * If a branch location is passed in, that a filtered list of pickup locations is returned
    */
-  function arborcat_check_locker_availability($queryDate, $locationObject)
-  {
-      $availableLockers = 0;
-      // Query current arborcat_patron_pickup_request records for the date and timePeriod to get inuse count
-      // fields pickupDate & timeSlot
-      $db = \Drupal::database();
-      $pickup_point = $locationObject->locationId;
+  function arborcat_check_locker_availability($queryDate, $locationObject) {
+    $availableLockers = 0;
+    // Query current arborcat_patron_pickup_request records for the date and timePeriod to get inuse count
+    // fields pickupDate & timeSlot
+    $db = \Drupal::database();
+    $pickup_point = $locationObject->locationId;
 
-      $query = $db->select('arborcat_patron_pickup_request', 'appr')
-        ->fields('appr', ['patronId'])
-        ->condition('pickupDate', $queryDate)
-        ->condition('pickupLocation', $pickup_point, '=')
-        ->groupBy('patronId');
-      $results = $query->execute()->fetchAll();
+    $query = $db->select('arborcat_patron_pickup_request', 'appr')
+      ->fields('appr', ['patronId'])
+      ->condition('pickupDate', $queryDate)
+      ->condition('pickupLocation', $pickup_point, '=')
+      ->groupBy('patronId');
+    $results = $query->execute()->fetchAll();
 
-      $lockersInUse = count($results);
-      $availableLockers = $locationObject->maxLockers - $lockersInUse;
-      
-      return ($availableLockers > 0);
+    $lockersInUse = count($results);
+    $availableLockers = $locationObject->maxLockers - $lockersInUse;
+    
+    return ($availableLockers > 0);
   }
 
-  function loadPatronEligibleHolds($patron_barcode, $requestLocation=null)
-  {
-      $guzzle = \Drupal::httpClient();
-      $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-      $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
-      $selfCheckApi_key .= '-' .  $patron_barcode;
+  function arborcat_load_patron_eligible_holds($patron_barcode, $requestLocation=NULL) {
+    $guzzle = \Drupal::httpClient();
+    $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+    $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
+    $selfCheckApi_key .= '-' .  $patron_barcode;
 
-      try {
-        $patron_holds = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/holds")->getBody()->getContents(), true);
+    try {
+      $patron_holds = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/holds")->getBody()->getContents(), TRUE);
 
-        // For debugging LWK  
-        // $jsonData = file_get_contents('10005279_21621034452183_holds.txt');
-        // $patron_holds = json_decode($jsonData, true);
+      // For debugging LWK  
+      // $jsonData = file_get_contents('10005279_21621034452183_holds.txt');
+      // $patron_holds = json_decode($jsonData, TRUE);
 
-      } catch (Exception $e) {
-        $eligible_holds['error'] = 'Info not found';
-        return $eligible_holds;
-      }
-      $eligible_holds = [];
-      //start at 1 to avoid issue with eligible holds array not being zero-based
-      $i=1;
-
-      $mel_mappings = [
-            113 => 102,
-            114 => 103,
-            115 => 104,
-            116 => 105,
-            117 => 106
-      ];
-
-      $db = \Drupal::database();
-      if (count($patron_holds)) {
-          foreach ($patron_holds as $hold) {
-              if ($hold['status'] == 'Ready for Pickup') {
-                  // check if there is a requestLocation to filter on. If not, set $includeLocationBoolean to true, otherwise perform check for location match
-                  $includeLocationBoolean = ($requestLocation == null) ? true : ($hold['hold']['pickup_lib'] == $requestLocation);
-                  if ($includeLocationBoolean || isset($mel_mappings[$hold['hold']['pickup_lib']])) {
-                      // if pickup appt already set, don't display item
-                      $pickup_req_exists = $db->query("SELECT * from arborcat_patron_pickup_request WHERE requestId = :hid", [':hid' => $hold['id']])->fetch();
-                      if (isset($pickup_req_exists->id)) {
-                          continue;
-                      }
-                      $shelf_expire = date('Y-m-d', strtotime($hold['hold']['shelf_expire_time']));
-                      if (arborcat_eligible_for_locker($hold) && $shelf_expire >= date('Y-m-d')) {
-                          $eligible_holds[$i] = [
-                                'Title' => $hold['title'],
-                                'Status' => $hold['status'],
-                                'PickupLoc' => $hold['pickup'],
-                                'pickup_lib' => $hold['hold']['pickup_lib'],
-                                'holdId' => $hold['id'],
-                                'usr' => $hold['hold']['usr']
-                            ];
-                          $i++;
-                      }
-                  }
-              }
-          }
-      }
+    } catch (Exception $e) {
+      $eligible_holds['error'] = 'Info not found';
       return $eligible_holds;
+    }
+    $eligible_holds = [];
+    //start at 1 to avoid issue with eligible holds array not being zero-based
+    $i=1;
+
+    $mel_mappings = [
+          113 => 102,
+          114 => 103,
+          115 => 104,
+          116 => 105,
+          117 => 106
+    ];
+
+    $db = \Drupal::database();
+    if (count($patron_holds)) {
+        foreach ($patron_holds as $hold) {
+            if ($hold['status'] == 'Ready for Pickup') {
+                // check if there is a requestLocation to filter on. If not, set $includeLocationBoolean to TRUE, otherwise perform check for location match
+                $includeLocationBoolean = ($requestLocation == NULL) ? TRUE : ($hold['hold']['pickup_lib'] == $requestLocation);
+                if ($includeLocationBoolean || isset($mel_mappings[$hold['hold']['pickup_lib']])) {
+                    // if pickup appt already set, don't display item
+                    $pickup_req_exists = $db->query("SELECT * from arborcat_patron_pickup_request WHERE requestId = :hid", [':hid' => $hold['id']])->fetch();
+                    if (isset($pickup_req_exists->id)) {
+                        continue;
+                    }
+                    $shelf_expire = date('Y-m-d', strtotime($hold['hold']['shelf_expire_time']));
+                    if (arborcat_eligible_for_locker($hold) && $shelf_expire >= date('Y-m-d')) {
+                        $eligible_holds[$i] = [
+                              'Title' => $hold['title'],
+                              'Status' => $hold['status'],
+                              'PickupLoc' => $hold['pickup'],
+                              'pickup_lib' => $hold['hold']['pickup_lib'],
+                              'holdId' => $hold['id'], f
+                              'usr' => $hold['hold']['usr']
+                          ];
+                        $i++;
+                    }
+                }
+            }
+        }
+    }
+    return $eligible_holds;
   }
 
   function arborcat_get_scheduled_pickups($barcode) {
@@ -275,7 +266,7 @@ function arborcat_patron_fines_expired($fines, $patron)
     $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
     $selfCheckApi_key .= '-' .  $barcode;
 
-    $scheduled_pickups = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/scheduled-pickups")->getBody()->getContents(), true);
+    $scheduled_pickups = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/scheduled-pickups")->getBody()->getContents(), TRUE);
 
     return $scheduled_pickups;
   }

--- a/arborcat.module
+++ b/arborcat.module
@@ -217,12 +217,16 @@ function arborcat_patron_fines_expired($fines, $patron)
 
       try {
         $patron_holds = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/holds")->getBody()->getContents(), true);
+
+        // For debugging LWK  
+        // $jsonData = file_get_contents('10005279_21621034452183_holds.txt');
+        // $patron_holds = json_decode($jsonData, true);
+
       } catch (Exception $e) {
         $eligible_holds['error'] = 'Info not found';
         return $eligible_holds;
       }
       $eligible_holds = [];
-
       //start at 1 to avoid issue with eligible holds array not being zero-based
       $i=1;
 

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -2,8 +2,8 @@
   Drupal.behaviors.pickupRequestBehavior = {
     attach: function (context, settings) {
 
-      var max_locker_items_check = drupalSettings.arborcat.max_locker_items_check;
-
+    var max_locker_items_check = drupalSettings.arborcat.max_locker_items_check;
+      console.log('max_locker_items_check = ' + max_locker_items_check);
     $(function () {
       // INITIALIZATION/SETUP
 

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -1,66 +1,70 @@
 (function ($, Drupal) {
+  Drupal.behaviors.pickupRequestBehavior = {
+    attach: function (context, settings) {
 
-  $(function () {
-    // INITIALIZATION/SETUP
-  
+      var max_locker_items_check = drupalSettings.arborcat.max_locker_items_check;
 
-    // helper methods
-    function checkedItems() {
-      var numitems = $("#edit-item-table tbody tr").length;
-      var numchecked = 0;
-      for (var i = numitems; i > 0; i--) {
-        var id = 'edit-item-table' + '-' + i;
-        var checkeditem = $('#' + id).is(':checked');
-        numchecked += (checkeditem) ? 1 : 0;
-      }
-      return numchecked;
-    }
-   
-    function displayBanner(bannerText) {
-      // build the banner 
-      var msgWrapper = $(document.createElement('div'));
-      msgWrapper.addClass('status-messages')
-        .attr({ 'role': 'contentinfo', 'aria-label': 'Warning message' });
-      var statusMsg = $(document.createElement('div'));
-      statusMsg.addClass('warning')
-        .html(bannerText);
-      msgWrapper.append('<h2 class="visually-hidden">Warning Message</h2>')
-        .append(statusMsg);
-      $(msgWrapper).insertBefore('.outer-wrapper[role="main"]');
-    }
+    $(function () {
+      // INITIALIZATION/SETUP
 
-    // EVENT HANDLERS
-    // check for locker pickup method and greater than 6 items.
-    $('#edit-pickup-type').change(function () {
-      $('.status-messages').remove();
-
-      selectedText = $("#edit-pickup-type :selected").text();
-      var lowercaseSelected = selectedText.toLowerCase();
-      var numItemsSelected = checkedItems();
-      if (lowercaseSelected.includes('locker') && numItemsSelected > 6) {
-        // show the warning banner
-        displayBanner('Please note, the ' + numItemsSelected + ' checked items may not fit in the selected locker pickup method. Any items that do not fit in the locker will be placed in the lobby', 'warning');
-      }
-    });
-
-    // toggle checkbox status on row with click
-    $('#edit-item-table tbody tr').click(function(e) {
-      if (e.target.nodeName != 'INPUT') {
-        var checkBox = $(this).find('input[type=checkbox]');
-        var checkStatus = checkBox.prop('checked');
-        checkBox.prop('checked', !checkStatus);
-      }
-    });
-
-    // give confirmation before canceling requests
-    $('#edit-submit').click(function() {
-      if ($(this).val() == 'Cancel selected requests') {
-        var cancelHolds = confirm('Once the request is canceled, you will be removed from the waitlist');
-        if (!cancelHolds) {
-          return false;
+      // helper methods
+      function checkedItems() {
+        var numitems = $("#edit-item-table tbody tr").length;
+        var numchecked = 0;
+        for (var i = numitems; i > 0; i--) {
+          var id = 'edit-item-table' + '-' + i;
+          var checkeditem = $('#' + id).is(':checked');
+          numchecked += (checkeditem) ? 1 : 0;
         }
+        return numchecked;
       }
-    });
-  });
+      
+      function displayBanner(bannerText) {
+        // build the banner 
+        var msgWrapper = $(document.createElement('div'));
+        msgWrapper.addClass('status-messages')
+          .attr({ 'role': 'contentinfo', 'aria-label': 'Warning message' });
+        var statusMsg = $(document.createElement('div'));
+        statusMsg.addClass('warning')
+          .html(bannerText);
+        msgWrapper.append('<h2 class="visually-hidden">Warning Message</h2>')
+          .append(statusMsg);
+        $(msgWrapper).insertBefore('.outer-wrapper[role="main"]');
+      }
 
+      // EVENT HANDLERS
+      // check for locker pickup method and greater than 6 items.
+      $('#edit-pickup-type').change(function () {
+        $('.status-messages').remove();
+
+        selectedText = $("#edit-pickup-type :selected").text();
+        var lowercaseSelected = selectedText.toLowerCase();
+        var numItemsSelected = checkedItems();
+        if (lowercaseSelected.includes('locker') && numItemsSelected > max_locker_items_check) {
+          // show the warning banner
+          displayBanner('Please note, the ' + numItemsSelected + ' checked items may not fit in the selected locker pickup method. Any items that do not fit in the locker will be placed in the lobby', 'warning');
+        }
+      });
+
+      // toggle checkbox status on row with click
+      $('#edit-item-table tbody tr').click(function(e) {
+        if (e.target.nodeName != 'INPUT') {
+          var checkBox = $(this).find('input[type=checkbox]');
+          var checkStatus = checkBox.prop('checked');
+          checkBox.prop('checked', !checkStatus);
+        }
+      });
+
+      // give confirmation before canceling requests
+      $('#edit-submit').click(function() {
+        if ($(this).val() == 'Cancel selected requests') {
+          var cancelHolds = confirm('Once the request is canceled, you will be removed from the waitlist');
+          if (!cancelHolds) {
+            return false;
+          }
+        }
+      });
+    });
+    }
+  }
 })(jQuery, Drupal);

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -1,44 +1,46 @@
-// (function ($, Drupal, drupalSettings) {
-//   console.log("pickupRequest-functions.js - pickupRequest-functions.js ENTERED ENTERED ENTERED ENTERED ENTERED ENTERED ENTERED ENTERED ENTERED ENTERED ENTERED\n");
-//   Drupal.behaviors.toolbookingBehavior = {
-//     attach: function (context, settings) {
-
-//       console.log(">>> pickupRequest-functions.js - pickupRequest-functions.js ENTERED\n");
-
-
-//     }
-//   }
-// })(jQuery, Drupal, drupalSettings);
-
 (function ($, Drupal) {
 
   $(function () {
-    console.log(">>> >>>\n");
     // INITIALIZATION/SETUP
-    // Initially hide the pickup time item in the form as lobby selection is the default for any location
-    $(".form-item-pickup-time").hide();
+  
 
-    // Hiding/Showing the pickup time is commented out for now and will probably be removed in favor of the 
-    // Pickup method drop-down menu now containing entries for the lockers with the pickup time options.
+    // helper methods
+    function checkedItems() {
+      var numitems = $("#edit-item-table tbody tr").length;
+      var numchecked = 0;
+      for (var i = numitems; i > 0; i--) {
+        var id = 'edit-item-table' + '-' + i;
+        var checkeditem = $('#' + id).is(':checked');
+        numchecked += (checkeditem) ? 1 : 0;
+      }
+      return numchecked;
+    }
+   
+    function displayBanner(bannerText) {
+      // build the banner 
+      var msgWrapper = $(document.createElement('div'));
+      msgWrapper.addClass('status-messages')
+        .attr({ 'role': 'contentinfo', 'aria-label': 'Warning message' });
+      var statusMsg = $(document.createElement('div'));
+      statusMsg.addClass('warning')
+        .html(bannerText);
+      msgWrapper.append('<h2 class="visually-hidden">Warning Message</h2>')
+        .append(statusMsg);
+      $(msgWrapper).insertBefore('.outer-wrapper[role="main"]');
+    }
 
-    // $(document).on('change', '#edit-pickup-type', function () {
-    //   var selectedValue = $("#edit-pickup-type option:selected").text();
-    //   var lowercaseValue = selectedValue.toLowerCase();
-    //   console.log(">>> #edit-pickup-type' - selectedValue = " + lowercaseValue + "\n");
-    //   if (lowercaseValue.includes("locker")) {
-    //     console.log(">>> #edit-pickup-type - selected a locker\n");
-    //     $(".form-item-pickup-time").show();
-    //   } else {
-    //     console.log(">>> #edit-pickup-type - selected a lobby\n");
-    //     $(".form-item-pickup-time").hide();
-    //   }
-    // });
+    // EVENT HANDLERS
+    // check for locker pickup method and greater than 6 items.
+    $('#edit-pickup-type').change(function () {
+      $('.status-messages').remove();
 
-    $('#edit-pickup-time').click(function () {
-      console.log(">>> edit-pickup-time CLICK \n");
-      // $('html, body').animate({
-      //   scrollTop: $('#jump-link').offset().top - 40
-      // }, 0);
+      selectedText = $("#edit-pickup-type :selected").text();
+      var lowercaseSelected = selectedText.toLowerCase();
+      var numItemsSelected = checkedItems();
+      if (lowercaseSelected.includes('locker') && numItemsSelected > 6) {
+        // show the warning banner
+        displayBanner('Please note, the ' + numItemsSelected + ' checked items may not fit in the selected locker pickup method. Any items that do not fit in the locker will be placed in the lobby', 'warning');
+      }
     });
 
     // toggle checkbox status on row with click
@@ -59,36 +61,6 @@
         }
       }
     });
-
-    // $('#edit-pickup-date').change(function() {
-    //   var branch = $('input[data-drupal-selector=edit-branch]').val();
-    //   if (branch == 104) {
-    //     var slots = $('#edit-pickup-type');
-    //     slots.val('');
-    //     if ($(this).val() >= '2020-07-08') {
-    //       var options = {
-    //         '- Select -' : '',
-    //         'PTS Lobby, 12pm to 8pm' : '1002-0',
-    //         'PTS Locker, 6pm to 2pm' : '1012-4'
-    //       };
-
-    //     } else {
-    //       var options = {
-    //         '- Select -' : '',
-    //         'PTS Lobby, 12pm to 8pm' : '1002-0',
-    //         'PTS Locker, 9am to 1pm' : '1003-1',
-    //         'PTS Locker, 2pm to 7pm' : '1004-2',
-    //         'PTS Locker, 8pm to 8am' : '1005-3'
-    //       };
-    //     }
-    //       slots.empty();
-    //       $.each(options, function(key,value) {
-    //       slots.append($("<option></option>")
-    //          .attr("value", value).text(key));
-    //     });
-    //   }
-    // });
-
   });
 
 })(jQuery, Drupal);

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -30,6 +30,9 @@
         msgWrapper.append('<h2 class="visually-hidden">Warning Message</h2>')
           .append(statusMsg);
         $(msgWrapper).insertBefore('.outer-wrapper[role="main"]');
+        // make the view scroll so the warning is actually visible to the user
+        $('.status-messages')[0].scrollIntoView({ behavior: 'smooth' });
+
       }
 
       function selectedItemsCheck() {

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -60,34 +60,34 @@
       }
     });
 
-    $('#edit-pickup-date').change(function() {
-      var branch = $('input[data-drupal-selector=edit-branch]').val();
-      if (branch == 104) {
-        var slots = $('#edit-pickup-type');
-        slots.val('');
-        if ($(this).val() >= '2020-07-08') {
-          var options = {
-            '- Select -' : '',
-            'PTS Lobby, 12pm to 8pm' : '1002-0',
-            'PTS Locker, 6pm to 2pm' : '1012-4'
-          };
+    // $('#edit-pickup-date').change(function() {
+    //   var branch = $('input[data-drupal-selector=edit-branch]').val();
+    //   if (branch == 104) {
+    //     var slots = $('#edit-pickup-type');
+    //     slots.val('');
+    //     if ($(this).val() >= '2020-07-08') {
+    //       var options = {
+    //         '- Select -' : '',
+    //         'PTS Lobby, 12pm to 8pm' : '1002-0',
+    //         'PTS Locker, 6pm to 2pm' : '1012-4'
+    //       };
 
-        } else {
-          var options = {
-            '- Select -' : '',
-            'PTS Lobby, 12pm to 8pm' : '1002-0',
-            'PTS Locker, 9am to 1pm' : '1003-1',
-            'PTS Locker, 2pm to 7pm' : '1004-2',
-            'PTS Locker, 8pm to 8am' : '1005-3'
-          };
-        }
-          slots.empty();
-          $.each(options, function(key,value) {
-          slots.append($("<option></option>")
-             .attr("value", value).text(key));
-        });
-      }
-    });
+    //     } else {
+    //       var options = {
+    //         '- Select -' : '',
+    //         'PTS Lobby, 12pm to 8pm' : '1002-0',
+    //         'PTS Locker, 9am to 1pm' : '1003-1',
+    //         'PTS Locker, 2pm to 7pm' : '1004-2',
+    //         'PTS Locker, 8pm to 8am' : '1005-3'
+    //       };
+    //     }
+    //       slots.empty();
+    //       $.each(options, function(key,value) {
+    //       slots.append($("<option></option>")
+    //          .attr("value", value).text(key));
+    //     });
+    //   }
+    // });
 
   });
 

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -3,7 +3,7 @@
     attach: function (context, settings) {
 
     var max_locker_items_check = drupalSettings.arborcat.max_locker_items_check;
-      console.log('max_locker_items_check = ' + max_locker_items_check);
+
     $(function () {
       // INITIALIZATION/SETUP
 
@@ -32,11 +32,8 @@
         $(msgWrapper).insertBefore('.outer-wrapper[role="main"]');
       }
 
-      // EVENT HANDLERS
-      // check for locker pickup method and greater than 6 items.
-      $('#edit-pickup-type').change(function () {
+      function selectedItemsCheck() {
         $('.status-messages').remove();
-
         selectedText = $("#edit-pickup-type :selected").text();
         var lowercaseSelected = selectedText.toLowerCase();
         var numItemsSelected = checkedItems();
@@ -44,15 +41,21 @@
           // show the warning banner
           displayBanner('Please note, the ' + numItemsSelected + ' checked items may not fit in the selected locker pickup method. Any items that do not fit in the locker will be placed in the lobby', 'warning');
         }
+      }
+
+      // EVENT HANDLERS 
+
+      $('#edit-pickup-type').change(function () {
+        selectedItemsCheck();
+       });
+
+
+       $('#edit-item-table thead tr').click(function (e) {
+        selectedItemsCheck();
       });
 
-      // toggle checkbox status on row with click
       $('#edit-item-table tbody tr').click(function(e) {
-        if (e.target.nodeName != 'INPUT') {
-          var checkBox = $(this).find('input[type=checkbox]');
-          var checkStatus = checkBox.prop('checked');
-          checkBox.prop('checked', !checkStatus);
-        }
+        selectedItemsCheck();
       });
 
       // give confirmation before canceling requests

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -390,7 +390,7 @@ class DefaultController extends ControllerBase {
         '#barcode' => $barcode,
         '#scheduled_pickups' => $scheduled_pickups ?? NULL
       ];
-      
+
     return $render;
   }
 
@@ -493,7 +493,6 @@ class DefaultController extends ControllerBase {
     }
   }
 
-
   private function validateTransaction($pnum, $encrypted_barcode) {
     $returnval = FALSE;
     $barcode =  $this->barcodeFromPatronId($pnum);
@@ -505,44 +504,5 @@ class DefaultController extends ControllerBase {
         }
     }
     return $returnval;
-  }
-
-  // this needed? insert can be done on form submit
-  private function addPickupRequest($pickupLocation, $pickupDay, $timeSlot, $contactEmail, $contactPhone, $contactSMS) {
-    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-    if ($user->isAuthenticated()) {
-        $db = \Drupal::database();
-
-        $db->insert('arborcat_patron_pickup_request')
-        ->fields([
-          'uid' => $user->id(),
-          'pickupDay' => $pickupDay,
-          'timeSlot' => $timeSlot,
-          'pickupLocation' => $pickupLocation,
-          'contactEmail' => $contactEmail,
-          'contactPhone' => $contactPhone,
-          'contactSMS' => $contactSMS,
-          'timestamp' => time()
-        ])
-        ->execute();
-        $result['success'] = "Successfully added pickup request";
-    } else {
-        $result['error'] = 'You must be logged in to make a pickup request.';
-    }
-
-    return new JsonResponse($result);
-  }
-
-  public function hook_form_FORM_ID_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-    // Modification for the form with the given form ID goes here. For example, if
-    // FORM_ID is "user_register_form" this code would run only on the user
-    // registration form.
-
-    // Add a checkbox to registration form about agreeing to terms of use.
-    $form['terms_of_use'] = array(
-        '#type' => 'checkbox',
-        '#title' => t("I agree with the website's terms and conditions."),
-        '#required' => TRUE,
-    );
   }
 }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -415,13 +415,8 @@ class DefaultController extends ControllerBase
         $location = \Drupal::request()->query->get('location');
         $seeddb = \Drupal::request()->query->get('seeddb');
         
-        $barcode =  $this->barcodeFromPatronId($patronId);
-        $eligibleHolds = loadPatronEligibleHolds($barcode);
-        die();
-
-
-
-
+        $barcode =  '21621034452183';   $this->barcodeFromPatronId($patronId);
+        $eligibleHolds = loadPatronEligibleHolds('21621034452183');
 
         if (strlen($seeddb) > 0) {
             $this->addPickupRequest($patronId, '$9999901', '104', '2020-06-17', '0', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
@@ -434,8 +429,6 @@ class DefaultController extends ControllerBase
             } else {
                 $location = '102';
             }
-
-
     
             if (strlen($patronId) > 0) {
                 $barcode =  $this->barcodeFromPatronId($patronId);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -355,7 +355,6 @@ class DefaultController extends ControllerBase
         $search_form = \Drupal::formBuilder()->getForm('\Drupal\arborcat\Form\ArborcatHoldsReadySearchForm');
 
         $current_uri = \Drupal::request()->getRequestUri();
-        $this->dblog('1', json_encode($current_uri));
 
         $barcode = \Drupal::request()->get('bcode');
 
@@ -565,21 +564,5 @@ class DefaultController extends ControllerBase
             '#title' => t("I agree with the website's terms and conditions."),
             '#required' => true,
         );
-    }
-
-    /*
-    * Debugging routine to log to the <root folder>/LWKLWK.log
-    */
-    public function dblog(...$thingsToLog)
-    {
-        $lineToLog = '';
-        foreach ($thingsToLog as $item) {
-            $lineToLog = $lineToLog . ' ' . print_r($item, true);
-        }
-        // prepend date/time onto log line
-        $nowDateTime = new DrupalDateTime();
-        $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
-        $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
-        error_log($completeLine, 3, "LWKLWK.log");
     }
 }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -408,41 +408,34 @@ class DefaultController extends ControllerBase {
     $barcode = \Drupal::request()->query->get('barcode');
     $patronId = \Drupal::request()->query->get('patronid');
     $location = \Drupal::request()->query->get('location');
-    $seeddb = \Drupal::request()->query->get('seeddb');
     
-    if (strlen($seeddb) > 0) {
-        $this->addPickupRequest($patronId, '$9999901', '104', '2020-06-17', '0', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-        $this->addPickupRequest($patronId, '$9999902', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-        $this->addPickupRequest($patronId, '$9999903', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-        $this->addPickupRequest($patronId, '$9999904', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+    if (strlen($location) == 3) {
+        //$locations = pickupLocations($location);
     } else {
-        if (strlen($location) == 3) {
-            //$locations = pickupLocations($location);
-        } else {
-            $location = '102';
-        }
-
-        if (strlen($patronId) > 0) {
-            $barcode =  $this->barcodeFromPatronId($patronId);
-        } else {
-            $patronId = $this->patronIdFromBarcode($barcode);
-        }
-        if (14 === strlen($barcode)) {
-        		$pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
-            $encryptedBarcode = md5($pickup_requests_salt . $barcode);
-            $returnval = '<h2>' . $patronId .' -> '. $barcode . ' -> ' . $encryptedBarcode . '</h2><br>';
-        
-            $host = 'https://pinkeye.aadl.org';
-            $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
-            $html = '<a href="' . $link . '" target="_blank">' . $link  . '</a>';
-
-            $host = 'http://nginx.docker.localhost:8000';
-            $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
-            $html2 = '<br><a href="' . $link . '" target="_blank">' . $link  . '</a>';
-
-            $returnval .= $html . $html2;
-        }
+        $location = '102';
     }
+
+    if (strlen($patronId) > 0) {
+        $barcode =  $this->barcodeFromPatronId($patronId);
+    } else {
+        $patronId = $this->patronIdFromBarcode($barcode);
+    }
+    if (14 === strlen($barcode)) {
+        $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
+        $encryptedBarcode = md5($pickup_requests_salt . $barcode);
+        $returnval = '<h2>' . $patronId .' -> '. $barcode . ' -> ' . $encryptedBarcode . '</h2><br>';
+    
+        $host = 'https://pinkeye.aadl.org';
+        $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
+        $html = '<a href="' . $link . '" target="_blank">' . $link  . '</a>';
+
+        $host = 'http://nginx.docker.localhost:8000';
+        $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
+        $html2 = '<br><a href="' . $link . '" target="_blank">' . $link  . '</a>';
+
+        $returnval .= $html . $html2;
+    }
+    
     return [
       '#title' => 'pickup request test',
       '#markup' => $returnval

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -16,188 +16,186 @@ use Drupal\Core\Url;
 /**
  * Default controller for the arborcat module.
  */
-class DefaultController extends ControllerBase
-{
-    public function index()
-    {
-        return [
+class DefaultController extends ControllerBase {
+
+  public function index() {
+    return [
       '#theme' => 'catalog',
       '#catalog_slider' => fesliders_build_cat_slider(),
       '#community_slider' => fesliders_build_community_slider(119620),
       '#podcast_slider' => fesliders_build_podcasts_slider()
     ];
+  }
+
+  public function bibrecord_page($bnum) {
+    $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+
+    // Get Bib Record from API
+    $guzzle = \Drupal::httpClient();
+    try {
+      $json = json_decode($guzzle->get("$api_url/record/$bnum/harvest")->getBody()->getContents());
+      $bib_record = $json->bib;
+      // Copy from Elasticsearch record id to same format as CouchDB _id
+      $bib_record->_id = $bib_record->id;
+      //$bib_record->id = $bib_record->_id;
+    } catch (\Exception $e) {
+      $bib_record->_id = NULL;
     }
 
-    public function bibrecord_page($bnum) {
-      $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-
-      // Get Bib Record from API
-      $guzzle = \Drupal::httpClient();
-      try {
-        $json = json_decode($guzzle->get("$api_url/record/$bnum/harvest")->getBody()->getContents());
-        $bib_record = $json->bib;
-        // Copy from Elasticsearch record id to same format as CouchDB _id
-        $bib_record->_id = $bib_record->id;
-        //$bib_record->id = $bib_record->_id;
-      } catch (\Exception $e) {
-        $bib_record->_id = NULL;
-      }
-
-      if (!$bib_record->_id) {
-        $markup = "<p class=\"base-margin-top\">Sorry, the item you are looking for couldn't be found.</p>";
-        return [
-          '#title' => 'Record Not Found',
-          '#markup' => $markup
-        ];
-      }
-
-      $mat_types = $guzzle->get("$api_url/mat-names")->getBody()->getContents();
-      $mat_name = json_decode($mat_types);
-      $bib_record->mat_name = $mat_name->{$bib_record->mat_code};
-
-      $downloads = ['z','za','zb','zm','zp'];
-      if (in_array($bib_record->mat_code, $downloads)) {
-        // below is what will be used when couch records have the download_formats field
-        // foreach($bib_record->download_formats as $format) {
-        //   if ($bib_record->mat_code != 'z' && $bib_record->mat_code =! 'za') {
-        //     $download_url = $guzzle->get("$api_url/download/$bib_record->_id/$format")->getBody()->getContents();
-        //   } else {
-        //     $download_url = $guzzle->get("$api_url/download/$bib_record->_id/album/$format")->getBody()->getContents();
-        //   }
-        //   $bib_record->download_urls[$format] = json_decode($download_url)->download_url;
-        // }
-        if ($bib_record->mat_code == 'zb' || $bib_record->mat_code == 'zp') {
-          $download_url = $guzzle->get("$api_url/download/$bib_record->_id/pdf")->getBody()->getContents();
-          $bib_record->download_urls['pdf'] = json_decode($download_url)->download_url;
-        } elseif ($bib_record->mat_code == 'z' || $bib_record->mat_code == 'za') {
-          $download_url = $guzzle->get("$api_url/download/$bib_record->_id/album/mp3")->getBody()->getContents();
-          $bib_record->download_urls['mp3'] = json_decode($download_url)->download_url;
-        } elseif ($bib_record->mat_code == 'zm') {
-          $download_url = $guzzle->get("$api_url/download/$bib_record->_id/mp4")->getBody()->getContents();
-          $bib_record->download_urls['mp4'] = json_decode($download_url)->download_url;
-        }
-
-        if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
-          if ($player = summergame_get_active_player()) {
-            // Check for duplicate
-            $db = \Drupal::database();
-            $row = $db->query("SELECT * FROM sg_ledger WHERE pid = :pid AND type = 'File Download' AND metadata like :meta",
-                              [':pid' => $player['pid'], ':meta' => '%bnum:' . $bib_record->_id . '%'])->fetchObject();
-            if (!$row) {
-              $type = 'File Download';
-              $description = 'Downloaded ' . $bib_record->title . ' from our online catalog';
-              $metadata = 'bnum:' . $bib_record->_id;
-              $result = summergame_player_points($player['pid'], 50, $type, $description, $metadata);
-              drupal_set_message("You earned $result points for downloading $bib_record->title from the catalog");
-            }
-          }
-        }
-      }
-
-      if (isset($bib_record->tracks)) {
-        foreach ($bib_record->tracks as $k => $track) {
-          $download_url = $guzzle->get("$api_url/download/$bib_record->_id/track/$k")->getBody()->getContents();
-          $bib_record->tracks->{$k}->download_url = json_decode($download_url)->download_url;
-        }
-        $bib_record->tracks = (array) $bib_record->tracks;
-        ksort($bib_record->tracks);
-      }
-
-      if(isset($bib_record->syndetics)) {
-        $bib_record->syndetics = (array) $bib_record->syndetics;
-      }
-
-      // grab user api key for account actions
-      $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-      $user_api_key = $user->field_api_key->value;
-
-      $lists = arborcat_lists_get_lists($user->get('uid')->value);
-
-      // get community reviews
-      $db = \Drupal::database();
-      $query = $db->query("SELECT * FROM arborcat_reviews WHERE bib=:bib AND deleted=0",
-          [':bib' => $bib_record->id]);
-      $reviews = $query->fetchAll();
-      foreach ($reviews as $k => $review) {
-        $review_user = \Drupal\user\Entity\User::load($review->uid);
-        $reviews[$k]->username = (isset($review_user) ? $review_user->get('name')->value : 'unknown');
-      }
-
-      // set up review form for users
-      $review_form = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserRecordReviewForm', $bib_record->id, $bib_record->title);
-
-      // get commuity ratings
-      $query = $db->query("SELECT AVG(rating) as average, count(id) as total FROM arborcat_ratings WHERE bib=:bib and rating > 0",
-          [':bib' => $bib_record->id]);
-      $ratings = $query->fetch();
-      $ratings->average = round($ratings->average, 1);
-      $user_rating = $db->query("SELECT rating FROM arborcat_ratings WHERE bib=:bib AND uid=:uid",
-          [':bib' => $bib_record->id, ':uid' => $user->id()])->fetch();
-      $ratings->user_rating = $user_rating->rating;
-
-      // if summer game codes, convert to array so template can loop over
-      if (isset($bib_record->gamecodes)) {
-        if (\Drupal::moduleHandler()->moduleExists('summergame')) {
-          if (\Drupal::config('summergame.settings')->get('summergame_show_gamecodes_in_catalog') ||
-              $user->hasPermission('play test summergame')) {
-            $bib_record->sg_enabled = true;
-            $bib_record->sg_term = \Drupal::config('summergame.settings')->get('summergame_current_game_term');
-
-            $gamecodes = [];
-            foreach ($bib_record->gamecodes as $gameterm => $gameterm_gamecodes) {
-              foreach ($gameterm_gamecodes as $gamecode) {
-                $badges = $db->query('SELECT d.nid, d.title FROM node__field_badge_formula f, node_field_data d ' .
-                                     'WHERE f.entity_id = d.nid ' .
-                                     'AND f.field_badge_formula_value REGEXP :gamecode',
-                                     [':gamecode' => '[[:<:]]' . $gamecode . '[[:>:]]'])->fetchAll();
-
-                foreach ($badges as $badge) {
-                  $gc_data = [
-                    'text' => $gamecode,
-                    'badge' => [
-                      'id' => $badge->nid,
-                      'title' => $badge->title,
-                    ]
-                  ];
-                  $gamecodes[$gameterm][] = $gc_data;
-                }
-              }
-            }
-            $bib_record->gamecodes = $gamecodes;
-          }
-        }
-      }
-
+    if (!$bib_record->_id) {
+      $markup = "<p class=\"base-margin-top\">Sorry, the item you are looking for couldn't be found.</p>";
       return [
-        '#title' => $bib_record->title,
-        '#theme' => 'catalog_record',
-        '#record' => $bib_record,
-        '#api_key' => $user_api_key,
-        '#lists' => $lists,
-        '#reviews' => $reviews,
-        '#review_form' => $review_form,
-        '#ratings' => $ratings,
-        '#cache' => [ 'max-age' => 0 ]
+        '#title' => 'Record Not Found',
+        '#markup' => $markup
       ];
     }
 
-    public function moderate_reviews()
-    {
-        $db = \Drupal::database();
-        $page = pager_find_page();
-        $per_page = 50;
-        $offset = $per_page * $page;
-        $limit = (isset($offset) && isset($per_page) ? " LIMIT $offset, $per_page" : '');
-        $total = $db->query("SELECT COUNT(*) as total FROM arborcat_reviews WHERE staff_reviewed=0 AND deleted=0")->fetch()->total;
-        $reviews = $db->query("SELECT * FROM arborcat_reviews WHERE staff_reviewed=0 AND deleted=0 ORDER BY id DESC $limit")->fetchAll();
-        foreach ($reviews as $k => $review) {
-            $review_user = \Drupal\user\Entity\User::load($review->uid);
-            $reviews[$k]->username = (isset($review_user) ? $review_user->get('name')->value : 'unknown');
+    $mat_types = $guzzle->get("$api_url/mat-names")->getBody()->getContents();
+    $mat_name = json_decode($mat_types);
+    $bib_record->mat_name = $mat_name->{$bib_record->mat_code};
+
+    $downloads = ['z','za','zb','zm','zp'];
+    if (in_array($bib_record->mat_code, $downloads)) {
+      // below is what will be used when couch records have the download_formats field
+      // foreach($bib_record->download_formats as $format) {
+      //   if ($bib_record->mat_code != 'z' && $bib_record->mat_code =! 'za') {
+      //     $download_url = $guzzle->get("$api_url/download/$bib_record->_id/$format")->getBody()->getContents();
+      //   } else {
+      //     $download_url = $guzzle->get("$api_url/download/$bib_record->_id/album/$format")->getBody()->getContents();
+      //   }
+      //   $bib_record->download_urls[$format] = json_decode($download_url)->download_url;
+      // }
+      if ($bib_record->mat_code == 'zb' || $bib_record->mat_code == 'zp') {
+        $download_url = $guzzle->get("$api_url/download/$bib_record->_id/pdf")->getBody()->getContents();
+        $bib_record->download_urls['pdf'] = json_decode($download_url)->download_url;
+      } elseif ($bib_record->mat_code == 'z' || $bib_record->mat_code == 'za') {
+        $download_url = $guzzle->get("$api_url/download/$bib_record->_id/album/mp3")->getBody()->getContents();
+        $bib_record->download_urls['mp3'] = json_decode($download_url)->download_url;
+      } elseif ($bib_record->mat_code == 'zm') {
+        $download_url = $guzzle->get("$api_url/download/$bib_record->_id/mp4")->getBody()->getContents();
+        $bib_record->download_urls['mp4'] = json_decode($download_url)->download_url;
+      }
+
+      if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
+        if ($player = summergame_get_active_player()) {
+          // Check for duplicate
+          $db = \Drupal::database();
+          $row = $db->query("SELECT * FROM sg_ledger WHERE pid = :pid AND type = 'File Download' AND metadata like :meta",
+                            [':pid' => $player['pid'], ':meta' => '%bnum:' . $bib_record->_id . '%'])->fetchObject();
+          if (!$row) {
+            $type = 'File Download';
+            $description = 'Downloaded ' . $bib_record->title . ' from our online catalog';
+            $metadata = 'bnum:' . $bib_record->_id;
+            $result = summergame_player_points($player['pid'], 50, $type, $description, $metadata);
+            drupal_set_message("You earned $result points for downloading $bib_record->title from the catalog");
+          }
         }
+      }
+    }
 
-        $pager = pager_default_initialize($total, $per_page);
+    if (isset($bib_record->tracks)) {
+      foreach ($bib_record->tracks as $k => $track) {
+        $download_url = $guzzle->get("$api_url/download/$bib_record->_id/track/$k")->getBody()->getContents();
+        $bib_record->tracks->{$k}->download_url = json_decode($download_url)->download_url;
+      }
+      $bib_record->tracks = (array) $bib_record->tracks;
+      ksort($bib_record->tracks);
+    }
 
-        return [
+    if(isset($bib_record->syndetics)) {
+      $bib_record->syndetics = (array) $bib_record->syndetics;
+    }
+
+    // grab user api key for account actions
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    $user_api_key = $user->field_api_key->value;
+
+    $lists = arborcat_lists_get_lists($user->get('uid')->value);
+
+    // get community reviews
+    $db = \Drupal::database();
+    $query = $db->query("SELECT * FROM arborcat_reviews WHERE bib=:bib AND deleted=0",
+        [':bib' => $bib_record->id]);
+    $reviews = $query->fetchAll();
+    foreach ($reviews as $k => $review) {
+      $review_user = \Drupal\user\Entity\User::load($review->uid);
+      $reviews[$k]->username = (isset($review_user) ? $review_user->get('name')->value : 'unknown');
+    }
+
+    // set up review form for users
+    $review_form = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserRecordReviewForm', $bib_record->id, $bib_record->title);
+
+    // get commuity ratings
+    $query = $db->query("SELECT AVG(rating) as average, count(id) as total FROM arborcat_ratings WHERE bib=:bib and rating > 0",
+        [':bib' => $bib_record->id]);
+    $ratings = $query->fetch();
+    $ratings->average = round($ratings->average, 1);
+    $user_rating = $db->query("SELECT rating FROM arborcat_ratings WHERE bib=:bib AND uid=:uid",
+        [':bib' => $bib_record->id, ':uid' => $user->id()])->fetch();
+    $ratings->user_rating = $user_rating->rating;
+
+    // if summer game codes, convert to array so template can loop over
+    if (isset($bib_record->gamecodes)) {
+      if (\Drupal::moduleHandler()->moduleExists('summergame')) {
+        if (\Drupal::config('summergame.settings')->get('summergame_show_gamecodes_in_catalog') ||
+            $user->hasPermission('play test summergame')) {
+          $bib_record->sg_enabled = true;
+          $bib_record->sg_term = \Drupal::config('summergame.settings')->get('summergame_current_game_term');
+
+          $gamecodes = [];
+          foreach ($bib_record->gamecodes as $gameterm => $gameterm_gamecodes) {
+            foreach ($gameterm_gamecodes as $gamecode) {
+              $badges = $db->query('SELECT d.nid, d.title FROM node__field_badge_formula f, node_field_data d ' .
+                                    'WHERE f.entity_id = d.nid ' .
+                                    'AND f.field_badge_formula_value REGEXP :gamecode',
+                                    [':gamecode' => '[[:<:]]' . $gamecode . '[[:>:]]'])->fetchAll();
+
+              foreach ($badges as $badge) {
+                $gc_data = [
+                  'text' => $gamecode,
+                  'badge' => [
+                    'id' => $badge->nid,
+                    'title' => $badge->title,
+                  ]
+                ];
+                $gamecodes[$gameterm][] = $gc_data;
+              }
+            }
+          }
+          $bib_record->gamecodes = $gamecodes;
+        }
+      }
+    }
+
+    return [
+      '#title' => $bib_record->title,
+      '#theme' => 'catalog_record',
+      '#record' => $bib_record,
+      '#api_key' => $user_api_key,
+      '#lists' => $lists,
+      '#reviews' => $reviews,
+      '#review_form' => $review_form,
+      '#ratings' => $ratings,
+      '#cache' => [ 'max-age' => 0 ]
+    ];
+  }
+
+  public function moderate_reviews() {
+    $db = \Drupal::database();
+    $page = pager_find_page();
+    $per_page = 50;
+    $offset = $per_page * $page;
+    $limit = (isset($offset) && isset($per_page) ? " LIMIT $offset, $per_page" : '');
+    $total = $db->query("SELECT COUNT(*) as total FROM arborcat_reviews WHERE staff_reviewed=0 AND deleted=0")->fetch()->total;
+    $reviews = $db->query("SELECT * FROM arborcat_reviews WHERE staff_reviewed=0 AND deleted=0 ORDER BY id DESC $limit")->fetchAll();
+    foreach ($reviews as $k => $review) {
+        $review_user = \Drupal\user\Entity\User::load($review->uid);
+        $reviews[$k]->username = (isset($review_user) ? $review_user->get('name')->value : 'unknown');
+    }
+
+    $pager = pager_default_initialize($total, $per_page);
+
+    return [
       '#theme' => 'moderate_reviews',
       '#reviews' => $reviews,
       '#pager' => [
@@ -206,356 +204,344 @@ class DefaultController extends ControllerBase
       ],
       '#cache' => [ 'max-age' => 0 ]
     ];
+  }
+
+  public function approve_review($rid) {
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    $db = \Drupal::database();
+
+    // grab review uid
+    $query = $db->query(
+        "SELECT * FROM arborcat_reviews WHERE id=:rid",
+        [':rid' => $rid]
+    );
+    $result = $query->fetch();
+
+    if ($user->hasPermission('administer nodes')) {
+        $db->update('arborcat_reviews')
+    ->condition('id', $result->id)
+    ->fields([
+      'staff_reviewed' => 1
+    ])
+    ->execute();
+
+        $response['success'] = 'Review approved';
+    } else {
+        $response['error'] = "You don't have permission to approve this review";
     }
 
-    public function approve_review($rid)
-    {
-        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-        $db = \Drupal::database();
+    return new JsonResponse($response);
+  }
 
-        // grab review uid
-        $query = $db->query(
-            "SELECT * FROM arborcat_reviews WHERE id=:rid",
-            [':rid' => $rid]
-        );
-        $result = $query->fetch();
+  public function delete_review($rid) {
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    $db = \Drupal::database();
 
-        if ($user->hasPermission('administer nodes')) {
-            $db->update('arborcat_reviews')
-        ->condition('id', $result->id)
-        ->fields([
-          'staff_reviewed' => 1
-        ])
-        ->execute();
+    // grab review uid
+    $query = $db->query(
+        "SELECT * FROM arborcat_reviews WHERE id=:rid",
+        [':rid' => $rid]
+    );
+    $result = $query->fetch();
 
-            $response['success'] = 'Review approved';
-        } else {
-            $response['error'] = "You don't have permission to approve this review";
-        }
-
-        return new JsonResponse($response);
-    }
-
-    public function delete_review($rid)
-    {
-        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-        $db = \Drupal::database();
-
-        // grab review uid
-        $query = $db->query(
-            "SELECT * FROM arborcat_reviews WHERE id=:rid",
-            [':rid' => $rid]
-        );
-        $result = $query->fetch();
-
-        if ($user->get('uid')->value == $result->uid || $user->hasPermission('administer nodes') || $_GET['pointsomaticauth']) {
-            $db->update('arborcat_reviews')
-        ->condition('id', $result->id)
-        ->fields([
-          'deleted' => 1
-        ])
-        ->execute();
-            if (\Drupal::moduleHandler()->moduleExists('summergame')) {
-                if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
-                    if ($player = summergame_player_load_all($result->uid)) {
-                        $players = [];
-                        foreach ($player as $play) {
-                            $players[] = $play['pid'];
-                        }
-                        $type = 'Wrote Review';
-                        $metadata = 'bnum:' . $result->bib;
-                        $db->update('sg_ledger')
-              ->condition('pid', $players, 'IN')
-              ->condition('type', $type)
-              ->condition('metadata', $metadata)
-              ->fields([
-                'points' => 0,
-                'type' => 'Deleted Review'
-              ])
-              ->execute();
-                    }
-                }
-            }
-            $response['success'] = 'Review deleted';
-        } else {
-            $response['error'] = "You don't have permission to delete this review";
-        }
-
-        return new JsonResponse($response);
-    }
-
-    public function rate_record($bib, $rating)
-    {
-        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-        if ($user->isAuthenticated()) {
-            $db = \Drupal::database();
-            // check if user has already rated this item and update if so
-            $rated = $db->query(
-                "SELECT * FROM arborcat_ratings WHERE bib=:bib AND uid=:uid",
-                [':bib' => $bib, ':uid' => $user->id()]
-            )->fetch();
-            if (isset($rated->id)) {
-                $db->update('arborcat_ratings')
-            ->condition('id', $rated->id, '=')
-            ->condition('bib', $bib, '=')
-            ->fields([
-              'rating' => $rating
-            ])
-            ->execute();
-                $result['success'] = 'Rating updated!';
-            } else {
-                $db->insert('arborcat_ratings')
+    if ($user->get('uid')->value == $result->uid || $user->hasPermission('administer nodes') || $_GET['pointsomaticauth']) {
+        $db->update('arborcat_reviews')
+          ->condition('id', $result->id)
           ->fields([
-            'uid' => $user->id(),
-            'bib' => $bib,
-            'rating' => $rating,
-            'timestamp' => time()
+            'deleted' => 1
           ])
           ->execute();
-                $result['success'] = "You rated this item $rating out of 5!";
-                if (\Drupal::moduleHandler()->moduleExists('summergame')) {
-                    if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
-                        if ($player = summergame_get_active_player()) {
-                            $type = 'Rated an Item';
-                            $description = 'Added a Rating to the Catalog';
-                            $metadata = 'bnum:' . $bib;
-                            $points = summergame_player_points($player['pid'], 10, $type, $description, $metadata);
-                            $result['summergame'] = "You earned $points points for rating an item!";
-                        }
+        if (\Drupal::moduleHandler()->moduleExists('summergame')) {
+            if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
+                if ($player = summergame_player_load_all($result->uid)) {
+                    $players = [];
+                    foreach ($player as $play) {
+                        $players[] = $play['pid'];
+                    }
+                    $type = 'Wrote Review';
+                    $metadata = 'bnum:' . $result->bib;
+                    $db->update('sg_ledger')
+                      ->condition('pid', $players, 'IN')
+                      ->condition('type', $type)
+                      ->condition('metadata', $metadata)
+                      ->fields([
+                        'points' => 0,
+                        'type' => 'Deleted Review'
+                      ])
+                      ->execute();
+                }
+            }
+        }
+        $response['success'] = 'Review deleted';
+    } else {
+        $response['error'] = "You don't have permission to delete this review";
+    }
+
+    return new JsonResponse($response);
+  }
+
+  public function rate_record($bib, $rating) {
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    if ($user->isAuthenticated()) {
+        $db = \Drupal::database();
+        // check if user has already rated this item and update if so
+        $rated = $db->query(
+            "SELECT * FROM arborcat_ratings WHERE bib=:bib AND uid=:uid",
+            [':bib' => $bib, ':uid' => $user->id()]
+        )->fetch();
+        if (isset($rated->id)) {
+            $db->update('arborcat_ratings')
+        ->condition('id', $rated->id, '=')
+        ->condition('bib', $bib, '=')
+        ->fields([
+          'rating' => $rating
+        ])
+        ->execute();
+            $result['success'] = 'Rating updated!';
+        } else {
+            $db->insert('arborcat_ratings')
+      ->fields([
+        'uid' => $user->id(),
+        'bib' => $bib,
+        'rating' => $rating,
+        'timestamp' => time()
+      ])
+      ->execute();
+            $result['success'] = "You rated this item $rating out of 5!";
+            if (\Drupal::moduleHandler()->moduleExists('summergame')) {
+                if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
+                    if ($player = summergame_get_active_player()) {
+                        $type = 'Rated an Item';
+                        $description = 'Added a Rating to the Catalog';
+                        $metadata = 'bnum:' . $bib;
+                        $points = summergame_player_points($player['pid'], 10, $type, $description, $metadata);
+                        $result['summergame'] = "You earned $points points for rating an item!";
                     }
                 }
             }
-        } else {
-            $result['error'] = 'You must be logged in to rate an item.';
         }
-
-        return new JsonResponse($result);
+    } else {
+        $result['error'] = 'You must be logged in to rate an item.';
     }
 
-    public function request_for_patron($barcode, $bnum, $loc, $type)
-    {
-        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-        if ($user->hasRole('staff') || $user->hasRole('administrator')) {
-            $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-            $api_key = \Drupal::config('arborcat.settings')->get('api_key');
-            $guzzle = \Drupal::httpClient();
-            $hold = $guzzle->get("$api_url/patron/$barcode|$api_key/place_hold/$bnum/$loc/$type")->getBody()->getContents();
-            return new JsonResponse($hold);
+    return new JsonResponse($result);
+  }
+
+  public function request_for_patron($barcode, $bnum, $loc, $type) {
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    if ($user->hasRole('staff') || $user->hasRole('administrator')) {
+        $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+        $api_key = \Drupal::config('arborcat.settings')->get('api_key');
+        $guzzle = \Drupal::httpClient();
+        $hold = $guzzle->get("$api_url/patron/$barcode|$api_key/place_hold/$bnum/$loc/$type")->getBody()->getContents();
+        return new JsonResponse($hold);
+    }
+    return new JsonResponse('Request could not be processed');
+  }
+
+  // -----------------------------------------------------------
+  // ---------------- Pickup Request-related methods -----------
+  // -----------------------------------------------------------
+  public function pickup_locations_for_patron() {
+    $returnArray = [];
+
+    $search_form = \Drupal::formBuilder()->getForm('\Drupal\arborcat\Form\ArborcatHoldsReadySearchForm');
+
+    $current_uri = \Drupal::request()->getRequestUri();
+
+    $barcode = \Drupal::request()->get('bcode');
+
+    $locationURLs = [];
+    if (isset($barcode)) {
+      $eligibleHolds = loadPatronEligibleHolds($barcode);
+      if (!isset($eligibleHolds['error'])) {
+        // grab pickup appointments to display on form
+        $scheduled_pickups = arborcat_get_scheduled_pickups($barcode);
+        // Get the patron ID from the first hold object in $eligibleHolds. NOTE - this starts at offset [1]
+        $patronId = $eligibleHolds[1]['usr'];
+        $holdLocations = [];
+        // spin through the eligible holds and get the locations
+        foreach ($eligibleHolds as $holdobj) {
+            array_push($holdLocations, $holdobj['pickup_lib']);
         }
-        return new JsonResponse('Request could not be processed');
-    }
+        $holdLocations = array_unique($holdLocations);
 
-    // -----------------------------------------------------------
-    // ---------------- Pickup Request-related methods -----------
-    // -----------------------------------------------------------
-    public function pickup_locations_for_patron()
-    {
-        $returnArray = [];
+        $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+        $guzzle = \Drupal::httpClient();
+        $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
 
-        $search_form = \Drupal::formBuilder()->getForm('\Drupal\arborcat\Form\ArborcatHoldsReadySearchForm');
-
-        $current_uri = \Drupal::request()->getRequestUri();
-
-        $barcode = \Drupal::request()->get('bcode');
-
-        $locationURLs = [];
-        if (isset($barcode)) {
-          $eligibleHolds = loadPatronEligibleHolds($barcode);
-          if (!isset($eligibleHolds['error'])) {
-            // grab pickup appointments to display on form
-            $scheduled_pickups = arborcat_get_scheduled_pickups($barcode);
-            // Get the patron ID from the first hold object in $eligibleHolds. NOTE - this starts at offset [1]
-            $patronId = $eligibleHolds[1]['usr'];
-            $holdLocations = [];
-            // spin through the eligible holds and get the locations
-            foreach ($eligibleHolds as $holdobj) {
-                array_push($holdLocations, $holdobj['pickup_lib']);
-            }
-            $holdLocations = array_unique($holdLocations);
-
-            $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-            $guzzle = \Drupal::httpClient();
-            $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
-
-            
-            foreach ($holdLocations as $loc) {
-                $locationName = ($loc < 110) ? $locations->{$loc} : 'melcat';
-                $url = $this->createPickupURL($patronId, $barcode, $loc);
-                array_push($locationURLs, ['url'=>$url, 'loc'=>$loc, 'locname'=>$locationName]);
-            }
-          } else {
-            $locationURLs['error'] = 'Error looking up patron requests. Is this a valid barcode?';
-          }
-        }
-
-        return [
-            '#theme' => 'patron_requests_ready_locations_theme',
-            '#search_form' => $search_form,
-            '#location_urls' => $locationURLs,
-            '#barcode' => $barcode,
-            '#scheduled_pickups' => $scheduled_pickups ?? null
-        ];
-    }
-
-    private function createPickupURL($patronId, $barcode, $location)
-    {
-        $html = '';
-        $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
-        $encryptedBarcode = md5($pickup_requests_salt . $barcode);
-        $host = \Drupal::request()->getHost();
-        $link = 'https://'. $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
-        return $link;
-    }
-
-    public function pickup_test()
-    {
-        $returnval = '';
-        $barcode = \Drupal::request()->query->get('barcode');
-        $patronId = \Drupal::request()->query->get('patronid');
-        $location = \Drupal::request()->query->get('location');
-        $seeddb = \Drupal::request()->query->get('seeddb');
         
-        $barcode =  '21621034452183';   $this->barcodeFromPatronId($patronId);
-        $eligibleHolds = loadPatronEligibleHolds('21621034452183');
+        foreach ($holdLocations as $loc) {
+            $locationName = ($loc < 110) ? $locations->{$loc} : 'melcat';
+            $url = $this->createPickupURL($patronId, $barcode, $loc);
+            array_push($locationURLs, ['url'=>$url, 'loc'=>$loc, 'locname'=>$locationName]);
+        }
+      } else {
+        $locationURLs['error'] = 'Error looking up patron requests. Is this a valid barcode?';
+      }
+    }
 
-        if (strlen($seeddb) > 0) {
-            $this->addPickupRequest($patronId, '$9999901', '104', '2020-06-17', '0', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-            $this->addPickupRequest($patronId, '$9999902', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-            $this->addPickupRequest($patronId, '$9999903', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-            $this->addPickupRequest($patronId, '$9999904', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-        } else {
-            if (strlen($location) == 3) {
-                //$locations = pickupLocations($location);
-            } else {
-                $location = '102';
-            }
+    return [
+        '#theme' => 'patron_requests_ready_locations_theme',
+        '#search_form' => $search_form,
+        '#location_urls' => $locationURLs,
+        '#barcode' => $barcode,
+        '#scheduled_pickups' => $scheduled_pickups ?? NULL
+    ];
+  }
+
+  private function createPickupURL($patronId, $barcode, $location) {
+    $html = '';
+    $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
+    $encryptedBarcode = md5($pickup_requests_salt . $barcode);
+    $host = \Drupal::request()->getHost();
+    $link = 'https://'. $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
+    return $link;
+  }
+
+  public function pickup_test() {
+    $returnval = '';
+    $barcode = \Drupal::request()->query->get('barcode');
+    $patronId = \Drupal::request()->query->get('patronid');
+    $location = \Drupal::request()->query->get('location');
+    $seeddb = \Drupal::request()->query->get('seeddb');
     
-            if (strlen($patronId) > 0) {
-                $barcode =  $this->barcodeFromPatronId($patronId);
-            } else {
-                $patronId = $this->patronIdFromBarcode($barcode);
-            }
-            if (14 === strlen($barcode)) {
-                $encryptedBarcode = md5($pickup_requests_salt . $barcode);
-                $returnval = '<h2>' . $patronId .' -> '. $barcode . ' -> ' . $encryptedBarcode . '</h2><br>';
-            
-                $host = 'https://pinkeye.aadl.org';
-                $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
-                $html = '<a href="' . $link . '" target="_blank">' . $link  . '</a>';
- 
-                $host = 'http://nginx.docker.localhost:8000';
-                $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
-                $html2 = '<br><a href="' . $link . '" target="_blank">' . $link  . '</a>';
+    $barcode =  '21621034452183';   $this->barcodeFromPatronId($patronId);
+    $eligibleHolds = loadPatronEligibleHolds('21621034452183');
 
-                $returnval .= $html . $html2;
-            }
-        }
-        return [
-         '#title' => 'pickup request test',
-         '#markup' => $returnval
-        ];
-    }
-
-    public function pickup_request($pnum, $encrypted_barcode, $loc)
-    {
-        $mode = \Drupal::request()->query->get('mode');
-        $requestPickup_html = '';
-        if ($this->validateTransaction($pnum, $encrypted_barcode)) {
-            $requestPickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $pnum, $loc, $mode);
+    if (strlen($seeddb) > 0) {
+        $this->addPickupRequest($patronId, '$9999901', '104', '2020-06-17', '0', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+        $this->addPickupRequest($patronId, '$9999902', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+        $this->addPickupRequest($patronId, '$9999903', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+        $this->addPickupRequest($patronId, '$9999904', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+    } else {
+        if (strlen($location) == 3) {
+            //$locations = pickupLocations($location);
         } else {
-            drupal_set_message('The Pickup Request could not be processed');
+            $location = '102';
         }
-        $render[] = [
-                '#theme' => 'pickup_request_form',
-                '#formhtml' => $requestPickup_html,
-            ];
-        return $render;
-    }
 
-    private function barcodeFromPatronId($patronId)
-    {
-        $api_key = \Drupal::config('arborcat.settings')->get('api_key');
-        $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-        $guzzle = \Drupal::httpClient();
-        $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
-        $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
-        if ($json) {
-            $barcode =  $json->evg_user->card->barcode;
-            return $barcode;
+        if (strlen($patronId) > 0) {
+            $barcode =  $this->barcodeFromPatronId($patronId);
         } else {
-            return "";
+            $patronId = $this->patronIdFromBarcode($barcode);
         }
-    }
-    private function patronIdFromBarcode($barcode)
-    {
-        $api_key = \Drupal::config('arborcat.settings')->get('api_key');
-        $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-        $guzzle = \Drupal::httpClient();
-        $requestURL = "$api_url/patron?apikey=$api_key&barcode=$barcode";
-        $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
-        if ($json) {
-            $patronId =  $json->pid;
-            return $patronId;
-        } else {
-            return "";
-        }
-    }
-
-
-    private function validateTransaction($pnum, $encrypted_barcode)
-    {
-        $returnval = false;
+        if (14 === strlen($barcode)) {
+            $encryptedBarcode = md5($pickup_requests_salt . $barcode);
+            $returnval = '<h2>' . $patronId .' -> '. $barcode . ' -> ' . $encryptedBarcode . '</h2><br>';
         
-        $barcode =  $this->barcodeFromPatronId($pnum);
-        if (14 == strlen($barcode)) {
-            $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
-            $hashedBarcode = md5($pickup_requests_salt . $barcode);
+            $host = 'https://pinkeye.aadl.org';
+            $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
+            $html = '<a href="' . $link . '" target="_blank">' . $link  . '</a>';
 
-            if ($hashedBarcode == $encrypted_barcode) {
-                $returnval =  true;
-            }
+            $host = 'http://nginx.docker.localhost:8000';
+            $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
+            $html2 = '<br><a href="' . $link . '" target="_blank">' . $link  . '</a>';
+
+            $returnval .= $html . $html2;
         }
-        return $returnval;
     }
+    return [
+      '#title' => 'pickup request test',
+      '#markup' => $returnval
+    ];
+  }
 
-    // this needed? insert can be done on form submit
-    private function addPickupRequest($pickupLocation, $pickupDay, $timeSlot, $contactEmail, $contactPhone, $contactSMS)
-    {
-        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-        if ($user->isAuthenticated()) {
-            $db = \Drupal::database();
+  public function pickup_request($pnum, $encrypted_barcode, $loc) {
+    $mode = \Drupal::request()->query->get('mode');
+    $requestPickup_html = '';
+    if ($this->validateTransaction($pnum, $encrypted_barcode)) {
+        $requestPickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $pnum, $loc, $mode);
+    } else {
+        drupal_set_message('The Pickup Request could not be processed');
+    }
+    $render[] = [
+            '#theme' => 'pickup_request_form',
+            '#formhtml' => $requestPickup_html,
+        ];
+    return $render;
+  }
 
-            $db->insert('arborcat_patron_pickup_request')
-            ->fields([
-              'uid' => $user->id(),
-              'pickupDay' => $pickupDay,
-              'timeSlot' => $timeSlot,
-              'pickupLocation' => $pickupLocation,
-              'contactEmail' => $contactEmail,
-              'contactPhone' => $contactPhone,
-              'contactSMS' => $contactSMS,
-              'timestamp' => time()
-            ])
-            ->execute();
-            $result['success'] = "Successfully added pickup request";
-        } else {
-            $result['error'] = 'You must be logged in to make a pickup request.';
+  private function barcodeFromPatronId($patronId) {
+    $api_key = \Drupal::config('arborcat.settings')->get('api_key');
+    $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+    $guzzle = \Drupal::httpClient();
+    $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
+    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+    if ($json) {
+        $barcode =  $json->evg_user->card->barcode;
+        return $barcode;
+    } else {
+        return "";
+    }
+  }
+
+  private function patronIdFromBarcode($barcode) {
+    $api_key = \Drupal::config('arborcat.settings')->get('api_key');
+    $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+    $guzzle = \Drupal::httpClient();
+    $requestURL = "$api_url/patron?apikey=$api_key&barcode=$barcode";
+    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+    if ($json) {
+        $patronId =  $json->pid;
+        return $patronId;
+    } else {
+        return "";
+    }
+  }
+
+
+  private function validateTransaction($pnum, $encrypted_barcode) {
+    $returnval = false;
+    
+    $barcode =  $this->barcodeFromPatronId($pnum);
+    if (14 == strlen($barcode)) {
+        $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
+        $hashedBarcode = md5($pickup_requests_salt . $barcode);
+
+        if ($hashedBarcode == $encrypted_barcode) {
+            $returnval =  true;
         }
+    }
+    return $returnval;
+  }
 
-        return new JsonResponse($result);
+  // this needed? insert can be done on form submit
+  private function addPickupRequest($pickupLocation, $pickupDay, $timeSlot, $contactEmail, $contactPhone, $contactSMS) {
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+    if ($user->isAuthenticated()) {
+        $db = \Drupal::database();
+
+        $db->insert('arborcat_patron_pickup_request')
+        ->fields([
+          'uid' => $user->id(),
+          'pickupDay' => $pickupDay,
+          'timeSlot' => $timeSlot,
+          'pickupLocation' => $pickupLocation,
+          'contactEmail' => $contactEmail,
+          'contactPhone' => $contactPhone,
+          'contactSMS' => $contactSMS,
+          'timestamp' => time()
+        ])
+        ->execute();
+        $result['success'] = "Successfully added pickup request";
+    } else {
+        $result['error'] = 'You must be logged in to make a pickup request.';
     }
 
-    public function hook_form_FORM_ID_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id)
-    {
-        // Modification for the form with the given form ID goes here. For example, if
-        // FORM_ID is "user_register_form" this code would run only on the user
-        // registration form.
+    return new JsonResponse($result);
+  }
 
-        // Add a checkbox to registration form about agreeing to terms of use.
-        $form['terms_of_use'] = array(
-            '#type' => 'checkbox',
-            '#title' => t("I agree with the website's terms and conditions."),
-            '#required' => true,
-        );
-    }
+  public function hook_form_FORM_ID_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+    // Modification for the form with the given form ID goes here. For example, if
+    // FORM_ID is "user_register_form" this code would run only on the user
+    // registration form.
+
+    // Add a checkbox to registration form about agreeing to terms of use.
+    $form['terms_of_use'] = array(
+        '#type' => 'checkbox',
+        '#title' => t("I agree with the website's terms and conditions."),
+        '#required' => true,
+    );
+  }
 }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -357,6 +357,8 @@ class DefaultController extends ControllerBase {
       if (!isset($eligibleHolds['error'])) {
         // grab pickup appointments to display on form
         $scheduled_pickups = arborcat_get_scheduled_pickups($barcode);
+        dblog('$pickup_locations_for_patron:: AFTER CALL TO arborcat_get_scheduled_pickups, scheduled_pickups = ' . json_encode($scheduled_pickups));
+
         // Get the patron ID from the first hold object in $eligibleHolds. NOTE - this starts at offset [1]
         $patronId = $eligibleHolds[1]['usr'];
         $holdLocations = [];
@@ -458,6 +460,7 @@ class DefaultController extends ControllerBase {
     $render[] = [
             '#theme' => 'pickup_request_form',
             '#formhtml' => $requestPickup_html,
+            '#max_locker_items_check' => \Drupal::config('arborcat.settings')->get('max_locker_items_check')
         ];
     return $render;
   }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -383,13 +383,15 @@ class DefaultController extends ControllerBase {
       }
     }
 
-    return [
+    $render = [
         '#theme' => 'patron_requests_ready_locations_theme',
         '#search_form' => $search_form,
         '#location_urls' => $locationURLs,
         '#barcode' => $barcode,
         '#scheduled_pickups' => $scheduled_pickups ?? NULL
-    ];
+      ];
+      
+    return $render;
   }
 
   private function createPickupURL($patronId, $barcode, $location) {

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -139,7 +139,7 @@ class DefaultController extends ControllerBase {
       if (\Drupal::moduleHandler()->moduleExists('summergame')) {
         if (\Drupal::config('summergame.settings')->get('summergame_show_gamecodes_in_catalog') ||
             $user->hasPermission('play test summergame')) {
-          $bib_record->sg_enabled = true;
+          $bib_record->sg_enabled = TRUE;
           $bib_record->sg_term = \Drupal::config('summergame.settings')->get('summergame_current_game_term');
 
           $gamecodes = [];
@@ -353,7 +353,7 @@ class DefaultController extends ControllerBase {
 
     $locationURLs = [];
     if (isset($barcode)) {
-      $eligibleHolds = loadPatronEligibleHolds($barcode);
+      $eligibleHolds = arborcat_load_patron_eligible_holds($barcode);
       if (!isset($eligibleHolds['error'])) {
         // grab pickup appointments to display on form
         $scheduled_pickups = arborcat_get_scheduled_pickups($barcode);
@@ -407,7 +407,7 @@ class DefaultController extends ControllerBase {
     $seeddb = \Drupal::request()->query->get('seeddb');
     
     $barcode =  '21621034452183';   $this->barcodeFromPatronId($patronId);
-    $eligibleHolds = loadPatronEligibleHolds('21621034452183');
+    $eligibleHolds = arborcat_load_patron_eligible_holds('21621034452183');
 
     if (strlen($seeddb) > 0) {
         $this->addPickupRequest($patronId, '$9999901', '104', '2020-06-17', '0', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
@@ -492,7 +492,7 @@ class DefaultController extends ControllerBase {
 
 
   private function validateTransaction($pnum, $encrypted_barcode) {
-    $returnval = false;
+    $returnval = FALSE;
     
     $barcode =  $this->barcodeFromPatronId($pnum);
     if (14 == strlen($barcode)) {
@@ -500,7 +500,7 @@ class DefaultController extends ControllerBase {
         $hashedBarcode = md5($pickup_requests_salt . $barcode);
 
         if ($hashedBarcode == $encrypted_barcode) {
-            $returnval =  true;
+            $returnval =  TRUE;
         }
     }
     return $returnval;
@@ -541,7 +541,7 @@ class DefaultController extends ControllerBase {
     $form['terms_of_use'] = array(
         '#type' => 'checkbox',
         '#title' => t("I agree with the website's terms and conditions."),
-        '#required' => true,
+        '#required' => TRUE,
     );
   }
 }

--- a/src/Form/ArborcatAdminForm.php
+++ b/src/Form/ArborcatAdminForm.php
@@ -118,6 +118,13 @@ class ArborcatAdminForm extends ConfigFormBase
       '#maxlength' => 64,
       '#description' => t('self-check key for use with api requests pertaining to the patron data without the need to be signed in'),
     ];
-        return parent::buildForm($form, $form_state);
-    }
+ 
+         $form['max_locker_items_check'] = [
+      '#type' => 'number',
+      '#title' => t('Max Number of Items that should fit in a Locker'),
+      '#default_value' => \Drupal::config('arborcat.settings')->get('max_locker_items_check'),
+      '#description' => t('If more items that this number are selected for locker pickup, a warning will be displayed to the patron'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
 }

--- a/src/Form/LockerRequestForm.php
+++ b/src/Form/LockerRequestForm.php
@@ -8,11 +8,11 @@ use Predis\Client;
 
 class LockerRequestForm extends FormBase{
 
-	public function getFormId(){
+	public function getFormId() {
 		return 'locker_form_contents';
 	}
 
-	public function buildForm(array $form,FormStateInterface $form_state,$uid=NULL){
+	public function buildForm(array $form,FormStateInterface $form_state,$uid=NULL) {
 		$branch = $_GET["branch"];
 		if($branch=="mcb"){
 			$branch = "Malletts Creek Branch";
@@ -107,7 +107,7 @@ class LockerRequestForm extends FormBase{
 		  return $form;
 	}
 
-	function submitForm(array &$form, FormStateInterface $form_state){
+	function submitForm(array &$form, FormStateInterface $form_state) {
 		$messenger = \Drupal::messenger();
 		//parse telephone number into seven digit locker code
 		$lockercode = $form_state->getValue('lockercode');
@@ -228,7 +228,7 @@ class LockerRequestForm extends FormBase{
   		if (!valid_email_address($form_state->getValue('email'))) {
     		$form_state->setErrorByName('email', t('You must enter a valid e-mail address.'));
   		}
-		}
+	}
 }
 
 ?>

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -285,9 +285,8 @@ class UserPickupRequestForm extends FormBase {
             $messenger->addError(t("There are no request items selected."));
         } else {  // got at least one hold to be processed
             // Check for the number of items and whether they will fit in the selected locker
-            $lockerItemMaxCount = 6;
- 
-             $db = \Drupal::database();
+            $lockerItemMaxCount = \Drupal::config('arborcat.settings')->get('max_locker_items_check');
+            $db = \Drupal::database();
             $guzzle = \Drupal::httpClient();
             $api_key = \Drupal::config('arborcat.settings')->get('api_key');
             $api_url = \Drupal::config('arborcat.settings')->get('api_url');
@@ -307,7 +306,7 @@ class UserPickupRequestForm extends FormBase {
                     $cancel_time = date('Y-m-d');
                     $guzzle->get("$api_url/patron/$selfCheckApi_key-$patron_barcode/update_hold/" . $hold['holdId'] . "?cancel_time=$cancel_time&cancel_cause=6")->getBody()->getContents();
                 } else {
-                    set the expire date for each selected hold
+                    // set the expire date for each selected hold
                     $updated_hold = $guzzle->get("$api_url/patron/$selfCheckApi_key-$patron_barcode/update_hold/" . $hold['holdId'] . "?shelf_expire_time=$pickup_date 23:59:59")->getBody()->getContents();
                     // create arborcat_patron_pickup_request records for each of the selected holds
                     $db->insert('arborcat_patron_pickup_request')

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -330,13 +330,12 @@ class UserPickupRequestForm extends FormBase {
  
             $submit_message = ($cancel_holds ? 'Your requests were successfully canceled' : 'Pickup appointment scheduled for ' . date('F j', strtotime($pickup_date)) . ' at ' . $locations->{$branch});
             $messenger->addMessage($submit_message);
-        }
-
-        $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
-        $uid = $user->id();
-        $url = \Drupal\Core\Url::fromRoute('entity.user.canonical', ['user'=>$user->id()]);
-
-        return $form_state->setRedirectUrl($url);
+ 
+            $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+            $uid = $user->id();
+            $url = \Drupal\Core\Url::fromRoute('entity.user.canonical', ['user'=>$user->id()]);
+            return $form_state->setRedirectUrl($url);
+       }
     }
 
     public function arborcat_mail($key, $email_to, $patron, $code, $holds) {

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -173,7 +173,7 @@ class UserPickupRequestForm extends FormBase {
                     'phone' => 'Phone Call'
                 ],
                 '#description' => t('Select which ways you would like to be notified when your request is ready for pickup'),
-                '#required' => TRUE
+                '#required' => TRUE,
                 '#default_value' => ['email']
             ];
 

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -219,6 +219,49 @@ class UserPickupRequestForm extends FormBase {
         return $form;
     }
 
+    public function validateForm(array &$form, FormStateInterface $form_state)
+    {
+        if (!$form_state->getValue('cancel_holds')) {
+            // check to see if locker pickup
+            $lockers = [1003,1004,1005,1007,1008,1009,1012];
+            $pickup_point = (int) explode('-', $form_state->getValue('pickup_type'))[0];
+            if (in_array($pickup_point, $lockers)) {
+                $pickup_date =  $form_state->getValue('pickup_date');
+                if (($pickup_point == 1003 || $pickup_point == 1004 || $pickup_point == 1005) && $pickup_date >= '2020-07-08') {
+                    $form_state->setErrorByName('pickup_type', t('No lockers are available during the selected time. Please try another time option or day'));
+                }
+                if (!$form_state->getValue('phone')) {
+                    $form_state->setErrorByName('phone', t('A phone number is required for lockers so we can generate your locker code'));
+                }
+                $db = \Drupal::database();
+                // grab location object to pass to avail check
+                $query = $db->select('arborcat_pickup_location', 'apl')
+                    ->fields('apl', ['locationId', 'timePeriod', 'maxLockers'])
+                    ->condition('locationId', $pickup_point, '=')
+                    ->execute();
+                $pickup_location = $query->fetch();
+
+                $avail = arborcat_check_locker_availability($pickup_date, $pickup_location);
+
+                // if no avail lockers, set form error
+                if (!$avail) {
+                    $form_state->setErrorByName('pickup_type', t('All lockers are full during the selected time. Please try another time option or day'));
+                }
+            }
+            if ($form_state->getValue('notification_types')['email']) {
+                if (!$form_state->getValue('email')) {
+                    $form_state->setErrorByName('email', t('No email is set, but you requested an email notification.'));
+                } elseif (!valid_email_address($form_state->getValue('email'))) {
+                    $form_state->setErrorByName('email', t('You must enter a valid e-mail address.'));
+                }
+            }
+
+            if (($form_state->getValue('notification_types')['sms'] || $form_state->getValue('notification_types')['phone']) && !$form_state->getValue('phone')) {
+                $form_state->setErrorByName('phone', t('No phone number is set, but you requested a text and/or phone call.'));
+            }
+        }
+    }
+
     public function submitForm(array &$form, FormStateInterface $form_state)
     {
         $pickup_date =  $form_state->getValue('pickup_date');
@@ -329,49 +372,6 @@ class UserPickupRequestForm extends FormBase {
             }
             $mailManager = \Drupal::service('plugin.manager.mail');
             mail($email_to, $email_subject, $email_message, $email_headers);
-        }
-    }
-
-    public function validateForm(array &$form, FormStateInterface $form_state)
-    {
-        if (!$form_state->getValue('cancel_holds')) {
-            // check to see if locker pickup
-            $lockers = [1003,1004,1005,1007,1008,1009,1012];
-            $pickup_point = (int) explode('-', $form_state->getValue('pickup_type'))[0];
-            if (in_array($pickup_point, $lockers)) {
-                $pickup_date =  $form_state->getValue('pickup_date');
-                if (($pickup_point == 1003 || $pickup_point == 1004 || $pickup_point == 1005) && $pickup_date >= '2020-07-08') {
-                    $form_state->setErrorByName('pickup_type', t('No lockers are available during the selected time. Please try another time option or day'));
-                }
-                if (!$form_state->getValue('phone')) {
-                    $form_state->setErrorByName('phone', t('A phone number is required for lockers so we can generate your locker code'));
-                }
-                $db = \Drupal::database();
-                // grab location object to pass to avail check
-                $query = $db->select('arborcat_pickup_location', 'apl')
-                    ->fields('apl', ['locationId', 'timePeriod', 'maxLockers'])
-                    ->condition('locationId', $pickup_point, '=')
-                    ->execute();
-                $pickup_location = $query->fetch();
-
-                $avail = arborcat_check_locker_availability($pickup_date, $pickup_location);
-
-                // if no avail lockers, set form error
-                if (!$avail) {
-                    $form_state->setErrorByName('pickup_type', t('All lockers are full during the selected time. Please try another time option or day'));
-                }
-            }
-            if ($form_state->getValue('notification_types')['email']) {
-                if (!$form_state->getValue('email')) {
-                    $form_state->setErrorByName('email', t('No email is set, but you requested an email notification.'));
-                } elseif (!valid_email_address($form_state->getValue('email'))) {
-                    $form_state->setErrorByName('email', t('You must enter a valid e-mail address.'));
-                }
-            }
-
-            if (($form_state->getValue('notification_types')['sms'] || $form_state->getValue('notification_types')['phone']) && !$form_state->getValue('phone')) {
-                $form_state->setErrorByName('phone', t('No phone number is set, but you requested a text and/or phone call.'));
-            }
         }
     }
 

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -151,6 +151,10 @@ class UserPickupRequestForm extends FormBase {
                     $st = date_format($starttimeObj, "h:ia");
                     $endtimeObj = new dateTime($locationObj->timePeriodEnd);
                     $timePeriodFormatted = ', ' . date_format($starttimeObj, "ga") . ' to ' . date_format($endtimeObj, "ga");
+                    // check if this is an overnight time period
+                    if ($endtimeObj < $starttimeObj) {
+                        $timePeriodFormatted .= ' (overnight)';
+                    }
                     $namePlusTimePeriod = $locationObj->locationName . $timePeriodFormatted;
                     // concatenate the locationId and the timeslot into the key
                     $pickupOptions["$locationObj->locationId-$locationObj->timePeriod"] = $namePlusTimePeriod;
@@ -223,7 +227,7 @@ class UserPickupRequestForm extends FormBase {
     {
         if (!$form_state->getValue('cancel_holds')) {
             // check to see if locker pickup
-            $lockers = [1003,1004,1005,1007,1008,1009,1012];
+            $lockers = arborcat_lockerPickupLocations();                                        // [1003,1004,1005,1007,1008,1009,1012];
             $pickup_point = (int) explode('-', $form_state->getValue('pickup_type'))[0];
             if (in_array($pickup_point, $lockers)) {
                 $pickup_date =  $form_state->getValue('pickup_date');


### PR DESCRIPTION
this branch has been deployed to pinkeye for testing
Here's a URL to open the pickup request form for my account. I have 9 hold requests that are "ready for Pickup" which will be displayed in the form.
https://pinkeye.aadl.org/pickuprequest/10019313/319e8e98faa5b70153a2c95678754035/104
With 6 or more items checked in the left-hand list, if one selects the PTS locker as a pickup method the yellow/orange warning banner will be displayed.

Max number of items that will fit in a locker is configurable from arborcat admin settings. it is currently set to 6.