### PR TITLE
Pickup requests exclusion dates

### DIFF
--- a/arborcat.install
+++ b/arborcat.install
@@ -8,179 +8,177 @@
 /**
  * Implements hook_schema().
  */
-function arborcat_schema()
-{
-    $schema['arborcat_patron_pickup_request'] = [
-        'description' => 'table containing pickup requests ',
-        'fields' => [
-            'id' => [
-                'type' => 'serial',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-           'requestId' => [
-                'description' => 'request holdId',
-                'type' => 'int',
-                'size' => 'big',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-            'patronId' => [
-                'description' => 'Patron UID',
-                'type' => 'int',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-            'branch' => [
-                'description' => 'pickup branch',
-                'type' => 'varchar',
-                'length' => 10,
-                'default' => '',
-            ],
-            'timeSlot' => [
-                'type' => 'int',
-                'description' => 'time slot for locker pickup',
-            ],
-            'pickupDate' => [
-                'type' => 'varchar',
-                'length' => 50,
-                'default' => '',
-                'description' => 'Date to pickup requested item',
-            ],
-           'contactEmail' => [
-                'type' => 'varchar',
-                'length' => 50,
-                'default' => '',
-                'description' => 'email to notify patron',
-            ],
-             'contactPhone' => [
-                'type' => 'varchar',
-                'length' => 50,
-                'default' => '',
-                'description' => 'telephone number to notify patron using voicemail',
-            ],
-             'contactSMS' => [
-                'type' => 'varchar',
-                'length' => 50,
-                'default' => '',
-                'description' => 'cell phone number to notify patron using an SMS text message',
-            ],
-             'completed' => [
-                'type' => 'int',
-                'default' => 0,
-               'description' => 'set to 1 when hold is checked out and placed for pickup',
-             ],
-             'created' => [
-                'type' => 'int',
-                'default' => 0,
-               'description' => 'created timestamp',
-             ],
-             'locker_code' => [
-                'type' => 'varchar',
-                'length' => 50,
-                'default' => '',
-                'description' => 'phone for generating locker code',
-            ],
-            'requestType' => [
-                'type' => 'varchar',
-                'length' => 20,
-                'default' => 'HOLD_REQUEST',
-                'description' => 'type of pickup request',
-            ],
-     ],
-        'primary key' => ['id'],
-    ];
-
-    $schema['arborcat_pickup_location'] = [
-        'description' => 'table containing pickup locations with descriptions or each place',
-        'fields' => [
-            'locationId' => [
-                'description' => 'pickup location Id',
-                'type' => 'int',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-             'branchLocationId' => [
-                'description' => 'library branch location Id',
-                'type' => 'int',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-            'timePeriod' => [
-                'description' => 'time period for pickup',
-                'type' => 'int',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-            'timePeriodStart' => [
-                'description' => 'time period start for pickup',
-                'type' => 'time',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-           'timePeriodEnd' => [
-                'description' => 'time period end for pickup',
-                'type' => 'time',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-            'maxLockers' => [
-                'description' => 'max number of lockers for a time period and location',
-                'type' => 'int',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-            'locationName' => [
-                'type' => 'text',
-                'description' => 'unique name of pickup location',
-            ],
-            'locationDescription' => [
-                'type' => 'text',
-                'description' => 'Detailed description of the pickup location',
-            ],
-            'active' => [
-                'type' => 'int',
-                'default' => 0,
-                'not null' => true,
-               'description' => 'flag indicating whether pickup location is currently being used',
-             ],
+function arborcat_schema() {
+  $schema['arborcat_patron_pickup_request'] = [
+    'description' => 'table containing pickup requests ',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
       ],
-      'primary key' => ['locationId']
-    ];
-
-    $schema['arborcat_pickup_location_exclusion'] = [
-        'description' => 'table containing exlusion dates for library pickup locations',
-        'fields' => [
-            'id' => [
-                'type' => 'serial',
-                'unsigned' => true,
-                'not null' => true,
-            ],
-            'locationId' => [
-                'description' => 'pickup location Id',
-                'type' => 'int',
-                'unsigned' => TRUE,
-                'not null' => TRUE,
-            ],
-            'dateStart' => [
-                'description' => 'exclusion start date',
-                'type' => 'date',
-                'not null' => true,
-            ],
-            'dateEnd' => [
-                'description' => 'exclusion end date',
-                'type' => 'date',
-                'not null' => false,
-                 'default' => null,
-            ],
-            'notes' => [
-                'type' => 'text',
-                'description' => 'Deescription of exclusion',
-            ],
+      'requestId' => [
+        'description' => 'request holdId',
+        'type' => 'int',
+        'size' => 'big',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
       ],
-      'primary key' => ['id']
-    ];
+      'patronId' => [
+        'description' => 'Patron UID',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'branch' => [
+        'description' => 'pickup branch',
+        'type' => 'varchar',
+        'length' => 10,
+        'default' => '',
+      ],
+      'timeSlot' => [
+        'type' => 'int',
+        'description' => 'time slot for locker pickup',
+      ],
+      'pickupDate' => [
+        'type' => 'varchar',
+        'length' => 50,
+        'default' => '',
+        'description' => 'Date to pickup requested item',
+      ],
+    'contactEmail' => [
+        'type' => 'varchar',
+        'length' => 50,
+        'default' => '',
+        'description' => 'email to notify patron',
+      ],
+      'contactPhone' => [
+        'type' => 'varchar',
+        'length' => 50,
+        'default' => '',
+        'description' => 'telephone number to notify patron using voicemail',
+      ],
+      'contactSMS' => [
+        'type' => 'varchar',
+        'length' => 50,
+        'default' => '',
+        'description' => 'cell phone number to notify patron using an SMS text message',
+      ],
+      'completed' => [
+        'type' => 'int',
+        'default' => 0,
+        'description' => 'set to 1 when hold is checked out and placed for pickup',
+      ],
+      'created' => [
+        'type' => 'int',
+        'default' => 0,
+        'description' => 'created timestamp',
+      ],
+      'locker_code' => [
+        'type' => 'varchar',
+        'length' => 50,
+        'default' => '',
+        'description' => 'phone for generating locker code',
+      ],
+      'requestType' => [
+        'type' => 'varchar',
+        'length' => 20,
+        'default' => 'HOLD_REQUEST',
+        'description' => 'type of pickup request',
+      ],
+    ],
+    'primary key' => ['id'],
+  ];
 
+  $schema['arborcat_pickup_location'] = [
+    'description' => 'table containing pickup locations with descriptions or each place',
+    'fields' => [
+      'locationId' => [
+        'description' => 'pickup location Id',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'branchLocationId' => [
+        'description' => 'library branch location Id',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'timePeriod' => [
+        'description' => 'time period for pickup',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'timePeriodStart' => [
+        'description' => 'time period start for pickup',
+        'type' => 'time',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'timePeriodEnd' => [
+        'description' => 'time period end for pickup',
+        'type' => 'time',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'maxLockers' => [
+        'description' => 'max number of lockers for a time period and location',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'locationName' => [
+        'type' => 'text',
+        'description' => 'unique name of pickup location',
+      ],
+      'locationDescription' => [
+        'type' => 'text',
+        'description' => 'Detailed description of the pickup location',
+      ],
+      'active' => [
+        'type' => 'int',
+        'default' => 0,
+        'not null' => TRUE,
+        'description' => 'flag indicating whether pickup location is currently being used',
+      ],
+    ],
+    'primary key' => ['locationId']
+  ];
 
-    return $schema;
+  $schema['arborcat_pickup_location_exclusion'] = [
+    'description' => 'table containing exlusion dates for library pickup locations',
+    'fields' => [
+      'id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'locationId' => [
+        'description' => 'pickup location Id',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'dateStart' => [
+        'description' => 'exclusion start date',
+        'type' => 'date',
+        'not null' => TRUE,
+      ],
+      'dateEnd' => [
+        'description' => 'exclusion end date',
+        'type' => 'date',
+        'not null' => FALSE,
+        'default' => NULL,
+      ],
+      'notes' => [
+        'type' => 'text',
+        'description' => 'Deescription of exclusion',
+      ],
+    ],
+    'primary key' => ['id']
+  ];
+
+  return $schema;
 }

--- a/arborcat.install
+++ b/arborcat.install
@@ -70,37 +70,117 @@ function arborcat_schema()
                 'default' => 0,
                'description' => 'set to 1 when hold is checked out and placed for pickup',
              ],
-        ],
+             'created' => [
+                'type' => 'int',
+                'default' => 0,
+               'description' => 'created timestamp',
+             ],
+             'locker_code' => [
+                'type' => 'varchar',
+                'length' => 50,
+                'default' => '',
+                'description' => 'phone for generating locker code',
+            ],
+            'requestType' => [
+                'type' => 'varchar',
+                'length' => 20,
+                'default' => 'HOLD_REQUEST',
+                'description' => 'type of pickup request',
+            ],
+     ],
         'primary key' => ['id'],
     ];
 
     $schema['arborcat_pickup_location'] = [
         'description' => 'table containing pickup locations with descriptions or each place',
         'fields' => [
-           'locationId' => [
+            'locationId' => [
                 'description' => 'pickup location Id',
                 'type' => 'int',
                 'unsigned' => true,
                 'not null' => true,
             ],
-          'branchLocationId' => [
+             'branchLocationId' => [
                 'description' => 'library branch location Id',
                 'type' => 'int',
                 'unsigned' => true,
                 'not null' => true,
             ],
-            'locationName' => [
-                'description' => 'Patron UID',
-                'type' => 'varchar',
-                'length' => 50,
+            'timePeriod' => [
+                'description' => 'time period for pickup',
+                'type' => 'int',
+                'unsigned' => true,
                 'not null' => true,
             ],
-            'LocationDescription' => [
+            'timePeriodStart' => [
+                'description' => 'time period start for pickup',
+                'type' => 'time',
+                'unsigned' => true,
+                'not null' => true,
+            ],
+           'timePeriodEnd' => [
+                'description' => 'time period end for pickup',
+                'type' => 'time',
+                'unsigned' => true,
+                'not null' => true,
+            ],
+            'maxLockers' => [
+                'description' => 'max number of lockers for a time period and location',
+                'type' => 'int',
+                'unsigned' => true,
+                'not null' => true,
+            ],
+            'locationName' => [
+                'type' => 'text',
+                'description' => 'unique name of pickup location',
+            ],
+            'locationDescription' => [
                 'type' => 'text',
                 'description' => 'Detailed description of the pickup location',
             ],
+            'active' => [
+                'type' => 'int',
+                'default' => 0,
+                'not null' => true,
+               'description' => 'flag indicating whether pickup location is currently being used',
+             ],
       ],
       'primary key' => ['locationId']
     ];
+
+    $schema['arborcat_pickup_location_exclusion'] = [
+        'description' => 'table containing exlusion dates for library pickup locations',
+        'fields' => [
+            'id' => [
+                'type' => 'serial',
+                'unsigned' => true,
+                'not null' => true,
+            ],
+            'locationId' => [
+                'description' => 'pickup location Id',
+                'type' => 'int',
+                'unsigned' => TRUE,
+                'not null' => TRUE,
+            ],
+            'dateStart' => [
+                'description' => 'exclusion start date',
+                'type' => 'date',
+                'not null' => true,
+            ],
+            'dateEnd' => [
+                'description' => 'exclusion end date',
+                'type' => 'date',
+                'not null' => false,
+                 'default' => null,
+            ],
+            'notes' => [
+                'type' => 'text',
+                'description' => 'Deescription of exclusion',
+            ],
+      ],
+      'primary key' => ['id']
+    ];
+
+
     return $schema;
 }

--- a/arborcat.module
+++ b/arborcat.module
@@ -468,20 +468,19 @@ function processExclusionData($exclusionData) {
     $interval = \DateInterval::createFromDateString('1 day');
     $period = new \DatePeriod($start, $interval, $end);
     foreach ($period as $date) {
-      array_push($exclusionDates, $date->format('M. j'));
+      array_push($exclusionDates, $date->format('Y-m-d'));
    }
   }
 
   return $exclusionDates;
 }
 
-function arborcat_calculate_pickup_dates() {
-  $arrayOfDates = [];
- 
+function arborcat_calculate_pickup_dates() { 
   $startingDayOffset = 1; // Load these from ArborCat Settings?
-  $numPickupDays = 7;     // Load these from ArborCat Settings?
+  $numPickupDays = 90;     // Load these from ArborCat Settings?
   $startingDay = new DateTime('+' . $startingDayOffset . ' day');
-  $startingDayPlusPickup = new DateTime('+' . $numPickupDays . ' days');
+  $startingDayPlusPickupDays = clone $startingDay;
+  $startingDayPlusPickupDays->modify('+' . $numPickupDays . ' days');
 
   // now loop for x days and create a date string for each day, preceded with the day name
   // create a human friendly version - 'formattedDate' for display purposes in the UI
@@ -492,27 +491,26 @@ function arborcat_calculate_pickup_dates() {
   $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
   $query->fields('aple', ['locationId', 'dateStart', 'dateEnd']);
   $query->condition('dateStart', $startingDay->format('Y-m-d'), '>=');
-  $query->condition('dateStart', $startingDayPlusPickup->format('Y-m-d'), '<=');
+  $query->condition('dateStart', $startingDayPlusPickupDays->format('Y-m-d'), '<=');
   $query->condition('locationId', 9999, '=');
   $result = $query->execute();
   $exclusionData = $result->fetchAll();
 
-  $date_exclude = processExclusionData($exclusionData);
+  $exclusionDates = processExclusionData($exclusionData);
 
-  for ($x=0; $x < $numPickupDays; $x++) {
-    $theDate_mdY = $startingDay->format('M. j');
-    $day_of_week = intval($startingDay->format('w'));
+  $interval = \DateInterval::createFromDateString('1 day');
+  $period = new \DatePeriod($startingDay, $interval, $startingDayPlusPickupDays);
+
+  $pickupdates = [];
+  foreach ($period as $date) {
+    $theDate_mdY = $date->format('M. j');
+    $day_of_week = intval($date->format('w'));
     $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
     $datestring = $dayOfWeek . ', ' . $theDate_mdY;
-
-    $datestr_Ymd = $startingDay->format('Y-m-d');
-    $twoDates = array("date" => $datestr_Ymd, "formattedDate" => $datestring);
-
-    if (!in_array($theDate_mdY, $date_exclude)) {
-      $arrayOfDates[$datestr_Ymd] = $twoDates;
+    $datestr_Ymd = $date->format('Y-m-d');
+    if (!in_array($datestr_Ymd, $exclusionDates)) {
+      $pickupdates[$datestr_Ymd] = $datestring;
     }
-    $startingDay->modify('+1 day');
   }
-
-  return $arrayOfDates;
+  return $pickupdates;
 }

--- a/arborcat.module
+++ b/arborcat.module
@@ -120,9 +120,9 @@ function arborcat_lockers_available($branch) {
     curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
     $result = curl_exec($ch);
 
-    $simpleXML = simplexml_load_string($result);
+    $simple_xml = simplexml_load_string($result);
     $i=1;
-    $s = $simpleXML->doors->children();
+    $s = $simple_xml->doors->children();
     if ($s->assign1==0&$s->assign2==0&$s->assign3==0&$s->assign4==0) {
       $available = FALSE;
     } elseif ($s->assign1!==0||$s->assign2!==0||$s->assign3!==0||$s->assign4!==0) {
@@ -150,45 +150,45 @@ function arborcat_lockers_available($branch) {
   * returns a list of request pickup locations.
   * If a branch location is passed in, that a filtered list of pickup locations is returned
   */
-function arborcat_pickup_locations($destLocation = NULL, $lookupName = NULL, $frontBack = NULL, $lobbyOnly = NULL) {
+function arborcat_pickup_locations($dest_location = NULL, $lookup_name = NULL, $front_back = NULL, $lobby_only = NULL) {
   $db = \Drupal::database();
   $query = $db->select('arborcat_pickup_location', 'apl')
     ->fields('apl', ['locationId', 'branchLocationId', 'timePeriod', 'timePeriodStart', 'timePeriodEnd', 'maxLockers', 'locationName', 'locationDescription'])
     ->condition('active', 1, "=");
 
-  // if lookupName supplied, get lib locations and lookup the branch number.
-  // Then set the parameter $destlocation to the branch number. If set, the location filter will be applied
-  if (strlen($lookupName) > 0) {
+  // if lookup_name supplied, get lib locations and lookup the branch number.
+  // Then set the parameter $dest_location to the branch number. If set, the location filter will be applied
+  if (strlen($lookup_name) > 0) {
     $guzzle = \Drupal::httpClient();
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
     $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
     foreach ($locations as $key => $value) {
-      if (strpos($value, $lookupName) !== FALSE) {
-        $destLocation = $key;
+      if (strpos($value, $lookup_name) !== FALSE) {
+        $dest_location = $key;
 
         break;
       }
     }
   }
   // add in a condition if a location is supplied to filter on
-  if (3 == strlen($destLocation)) {
-    $query->condition('branchLocationId', (int) $destLocation, '=');
+  if (3 == strlen($dest_location)) {
+    $query->condition('branchLocationId', (int) $dest_location, '=');
   }
-  // add in a condition if a lobbyOnly is supplied to filter on
-  if (NULL != $lobbyOnly) {
+  // add in a condition if a lobby_only is supplied to filter on
+  if (NULL != $lobby_only) {
     $query->condition('maxLockers', 0, '=');
   }
   // add in a condition for 'Front' versus 'Back' in the location Name
-  if (NULL != $frontBack) {
-    $query->condition('locationName', "%" . $db->escapeLike($frontBack) . "%", 'like');
+  if (NULL != $front_back) {
+    $query->condition('locationName', "%" . $db->escapeLike($front_back) . "%", 'like');
   }
   $result = $query->execute();
-  $pickupLocationRecords = $result->fetchAll();
+  $pickup_location_records = $result->fetchAll();
 
-  return $pickupLocationRecords;
+  return $pickup_location_records;
 }
 
-/*
+ /*
   * returns an array of active locker pickup locations.
   */
 function arborcat_locker_pickup_locations() {
@@ -208,39 +208,39 @@ function arborcat_locker_pickup_locations() {
   * Checks the availability of a locker fo the specified date and timePeriod.
   * If a branch location is passed in, that a filtered list of pickup locations is returned
   */
-function arborcat_check_locker_availability($queryDate, $locationObject, $patronId) {
-  $availableLockers = 0;
+function arborcat_check_locker_availability($query_date, $location_object, $patron_id) {
+  $available_lockers = 0;
   // Query current arborcat_patron_pickup_request records for the date and timePeriod to get inuse count
   // fields pickupDate & timeSlot
   $db = \Drupal::database();
-  $pickup_point = $locationObject->locationId;
+  $pickup_point = $location_object->locationId;
 
   $query = $db->select('arborcat_patron_pickup_request', 'appr')
     ->fields('appr', ['patronId'])
-    ->condition('pickupDate', $queryDate)
+    ->condition('pickupDate', $query_date)
     ->condition('pickupLocation', $pickup_point, '=')
     ->groupBy('patronId');
   $results = $query->execute()->fetchCol();
 
-  $lockersInUse = count($results);
-  $availableLockers = $locationObject->maxLockers - $lockersInUse;
-  $returnval = FALSE;
+  $lockers_in_use = count($results);
+  $available_lockers = $location_object->maxLockers - $lockers_in_use;
+  $return_val = FALSE;
   // check whether this patron already has a pickup appointment already scheduled for this locker at this time. OR whether there are available lockers at this time
-  if (in_array($patronId, $results) || $availableLockers > 0) {
-    $returnval = TRUE;
+  if (in_array($patron_id, $results) || $available_lockers > 0) {
+    $return_val = TRUE;
   }
 
-  return ($returnval);
+  return ($return_val);
 }
 
-function arborcat_load_patron_eligible_holds($patron_barcode, $requestLocation=NULL) {
+function arborcat_load_patron_eligible_holds($patron_barcode, $request_location=NULL) {
   $guzzle = \Drupal::httpClient();
   $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-  $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
-  $selfCheckApi_key .= '-' .  $patron_barcode;
+  $self_check_api_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
+  $self_check_api_key .= '-' .  $patron_barcode;
 
   try {
-    $patron_holds = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/holds")->getBody()->getContents(), TRUE);
+    $patron_holds = json_decode($guzzle->get("$api_url/patron/$self_check_api_key/holds")->getBody()->getContents(), TRUE);
 
     // For debugging LWK
     // $jsonData = file_get_contents('10005279_21621034452183_holds.txt');
@@ -266,9 +266,9 @@ function arborcat_load_patron_eligible_holds($patron_barcode, $requestLocation=N
   if (count($patron_holds)) {
     foreach ($patron_holds as $hold) {
       if ($hold['status'] == 'Ready for Pickup') {
-        // check if there is a requestLocation to filter on. If not, set $includeLocationBoolean to TRUE, otherwise perform check for location match
-        $includeLocationBoolean = ($requestLocation == NULL) ? TRUE : ($hold['hold']['pickup_lib'] == $requestLocation);
-        if ($includeLocationBoolean || isset($mel_mappings[$hold['hold']['pickup_lib']])) {
+        // check if there is a request_location to filter on. If not, set $include_location_boolean to TRUE, otherwise perform check for location match
+        $include_location_boolean = ($request_location == NULL) ? TRUE : ($hold['hold']['pickup_lib'] == $request_location);
+        if ($include_location_boolean || isset($mel_mappings[$hold['hold']['pickup_lib']])) {
           // if pickup appt already set, don't display item
           $pickup_req_exists = $db->query("SELECT * from arborcat_patron_pickup_request WHERE requestId = :hid", [':hid' => $hold['id']])->fetch();
           if (isset($pickup_req_exists->id)) {
@@ -306,21 +306,21 @@ function arborcat_get_scheduled_pickups($barcode) {
   return $scheduled_pickups;
 }
 
-function arborcat_create_pickup_request_record($pickup_request_type, $customId, $patronId, $branch, $timeSlot, $pickupLocation, $pickupDate, $contactEmail, $contactSMS, $contactPhone, $lockerCode) {
+function arborcat_create_pickup_request_record($pickup_request_type, $custom_id, $patron_id, $branch, $time_slot, $pickup_location, $pickup_date, $contact_email, $contact_sms, $contact_phone, $locker_code) {
   // create arborcat_patron_pickup_request records for each of the selected holds
   $db = \Drupal::database();
 
-  // First check if the record already exists for this customId
+  // First check if the record already exists for this custom_id
   $results = [];
   try {
     $query = $db->select('arborcat_patron_pickup_request', 'appr')
       ->fields('appr', ['id'])
-      ->condition('requestId', $customId, '=');
+      ->condition('requestId', $custom_id, '=');
     $results = $query->execute()->fetchCol();
   } catch (Exception $e) {
     return -1;
   }
-  // If a record exists containing the $customId, just return the id of the record, otherwise insert a new record with the customId and return the $id of the new record
+  // If a record exists containing the $custom_id, just return the id of the record, otherwise insert a new record with the custom_id and return the $id of the new record
   if (count($results) > 0) {
     return $results[0];
   } else {
@@ -328,17 +328,17 @@ function arborcat_create_pickup_request_record($pickup_request_type, $customId, 
     try {
       $dbaction = $db->insert('arborcat_patron_pickup_request')->fields([
         'requestType'   => $pickup_request_type,
-        'requestId'     => $customId,
-        'patronId'      => $patronId,
+        'requestId'     => $custom_id,
+        'patronId'      => $patron_id,
         'branch'        => (int) $branch,
-        'timeSlot'      => $timeSlot,
-        'pickupLocation' => $pickupLocation,
-        'pickupDate'    => $pickupDate,
-        'contactEmail'  => $contactEmail,
-        'contactSMS'    => $contactSMS,
-        'contactPhone'  => $contactPhone,
+        'timeSlot'      => $time_slot,
+        'pickupLocation' => $pickup_location,
+        'pickupDate'    => $pickup_date,
+        'contactEmail'  => $contact_email,
+        'contactSMS'    => $contact_sms,
+        'contactPhone'  => $contact_phone,
         'created'       => time(),
-        'locker_code'   => $lockerCode
+        'locker_code'   => $locker_code
       ]);
       $id = $dbaction->execute();
 
@@ -351,14 +351,14 @@ function arborcat_create_pickup_request_record($pickup_request_type, $customId, 
   }
 }
 
-function barcode_from_patron_id($patronId) {
+function arborcat_barcode_from_patron_id($patron_id) {
   $api_key = \Drupal::config('arborcat.settings')->get('api_key');
   $api_url = \Drupal::config('arborcat.settings')->get('api_url');
   $guzzle = \Drupal::httpClient();
-  $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
+  $request_url = "$api_url/patron?apikey=$api_key&pnum=$patron_id";
 
   try {
-    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+    $json = json_decode($guzzle->get($request_url)->getBody()->getContents());
   } 
   catch (Exception $e) {
 
@@ -375,22 +375,22 @@ function barcode_from_patron_id($patronId) {
   }
 }
 
-function patron_id_from_barcode($barcode) {
+function arborcat_patron_id_from_barcode($barcode) {
   $api_key = \Drupal::config('arborcat.settings')->get('api_key');
   $api_url = \Drupal::config('arborcat.settings')->get('api_url');
   $guzzle = \Drupal::httpClient();
-  $requestURL = "$api_url/patron?apikey=$api_key&barcode=$barcode";
+  $request_url = "$api_url/patron?apikey=$api_key&barcode=$barcode";
     try {
-      $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+      $json = json_decode($guzzle->get($request_url)->getBody()->getContents());
     } 
     catch (Exception $e) {
 
     return "";
   }
   if ($json) {
-    $patronId =  $json->pid;
+    $patron_id =  $json->pid;
 
-    return $patronId;
+    return $patron_id;
   } 
   else {
     
@@ -399,224 +399,136 @@ function patron_id_from_barcode($barcode) {
 }
 
   
-function arborcat_custom_pickup_request($pickup_request_type, $customPickupRequestId) {
-  $resultMessage = '';
+function arborcat_custom_pickup_request($pickup_request_type, $custom_pickup_request_id) {
+  $result_message = '';
   if ($pickup_request_type == 'PRINT_JOB' || $pickup_request_type == 'GRAB_BAG') {
     // Extract fields from the printJob request form
     $db = \Drupal::database();
     $query = $db->select('webform_submission_data', 'wsd');
     $query->fields('wsd', ['name', 'value']);
-    $query->condition('sid', $customPickupRequestId, '=');
-    $rawNameValueResults= $query->execute()->fetchAll();
+    $query->condition('sid', $custom_pickup_request_id, '=');
+    $raw_name_value_results= $query->execute()->fetchAll();
 
     // process the raw results and create an associative array of the results.
     // NOTE notification_options can have multiple entries and this is handled by creating a regular array of the different result values
-    $assocResults = [];
-    foreach ($rawNameValueResults as $entry) {
+    $assoc_results = [];
+    foreach ($raw_name_value_results as $entry) {
       $keyname = $entry->name;
-      if ("notification_options" == $keyname) {
-        if (!array_key_exists($keyname, $assocResults)) {
-          $assocResults[$keyname] = [];
+      if ("notification_options" == $key_name) {
+        if (!array_key_exists($key_name, $assoc_results)) {
+          $assoc_results[$key_name] = [];
         }
-        array_push($assocResults[$keyname], $entry->value);
+        array_push($assoc_results[$key_name], $entry->value);
       } else {
-        $assocResults[$keyname] = $entry->value;
+        $assoc_results[$key_name] = $entry->value;
       }
     }
 
-    if (count($assocResults) > 0) {
-      $barcode = $assocResults['barcode'];
-      $patronId = (strlen($barcode) == 14) ? patron_id_from_barcode($barcode) : NULL;
-      $branchNameArray = explode(" ", $assocResults['delivery_method']);
-      if ($branchNameArray[0] == 'Mail') {  // Mail to Patron option - no pickup request should be created
-        $resultMessage = 'SUCCESS';
+    if (count($assoc_results) > 0) {
+      $bar_code = $assoc_results['barcode'];
+      $patron_id = (strlen($bar_code) == 14) ? arborcat_patron_id_from_barcode($bar_code) : NULL;
+      $branch_name_array = explode(" ", $assoc_results['delivery_method']);
+      if ($branch_name_array[0] == 'Mail') {  // Mail to Patron option - no pickup request should be created
+        $result_message = 'SUCCESS';
       }
       else {
-        $frontBack = ($branchNameArray[1] == 'Back' || $branchNameArray[1] == 'Front') ? $branchNameArray[1] : NULL;
-        $pickupLocations = arborcat_pickup_locations(NULL, $branchNameArray[0], $frontBack, TRUE);
-        $branch = $pickupLocations[0]->branchLocationId;
-        $pickupLocation = $pickupLocations[0]->locationId;
+        $front_back = ($branch_name_array[1] == 'Back' || $branch_name_array[1] == 'Front') ? $branch_name_array[1] : NULL;
+        $pickup_locations = arborcat_pickup_locations(NULL, $branch_name_array[0], $front_back, TRUE);
+        $branch = $pickup_locations[0]->branchLocationId;
+        $pickup_location = $pickup_locations[0]->locationId;
 
-        $timeslot = 0;
-        $pickupDate = $assocResults['pickup_date'];
-        $patronPhone = $assocResults['patron_phone'];
-        $patronEmail = $assocResults['patron_email'];
-        $notification_options = $assocResults['notification_options'];
+        $time_slot = 0;
+        $pickup_date = $assoc_results['pickup_date'];
+        $patron_phone = $assoc_results['patron_phone'];
+        $patron_email = $assoc_results['patron_email'];
+        $notification_options = $assoc_results['notification_options'];
         // create new arborcat_pickup_request_record (if one does not already exist)
         $result = arborcat_create_pickup_request_record(
           $pickup_request_type,
-          $customPickupRequestId,
-          $patronId,
+          $custom_pickup_request_id,
+          $patron_id,
           $branch,
-          $timeslot,
-          $pickupLocation,
-          $pickupDate,
-          $patronEmail,
-          (in_array('email', array_map('strtolower', $notification_options))) ? $patronEmail : NULL,
-          (in_array('text', array_map("strtolower", $notification_options))) ? $patronPhone : NULL,
-          (in_array('phone call', array_map("strtolower", $notification_options))) ? $patronPhone : NULL,
-          $patronPhone ?? NULL
+          $time_slot,
+          $pickup_location,
+          $pickup_date,
+          $patron_email,
+          (in_array('email', array_map('strtolower', $notification_options))) ? $patron_email : NULL,
+          (in_array('text', array_map("strtolower", $notification_options))) ? $patron_phone : NULL,
+          (in_array('phone call', array_map("strtolower", $notification_options))) ? $patron_phone : NULL,
+          $patron_phone ?? NULL
         );
                                       
         if ($result > 0) {
-          $resultMessage = 'SUCCESS';
+          $result_message = 'SUCCESS';
         } else {
-          $resultMessage = 'Failed to create Pickup Request Record';
+          $result_message = 'Failed to create Pickup Request Record';
         }
       }
     }
   } elseif ($pickup_request_type == 'SG_ORDER') {
   }
 
-  return $resultMessage;
+  return $result_message;
 }
 
-function arborcat_get_pickup_dates($location, $startDateYmd, $endDateYmd) {
+function arborcat_get_pickup_dates($location, $start_date_ymd, $end_date_ymd) {
   // Load exclusion dates for date range defined in the two params from the table: arborcat_pickup_location_exclusion
   // For all branches (locationId=9999)
-  $pickupdates = [];
+  $pickup_dates = [];
   // Loop through each date, 1 day at a time, checking if there is an exclusion.
-  $date1 = new DateTime($startDateYmd);
-  $endingDate = new DateTime($endDateYmd);
-  while ($date1 <= $endingDate) {
+  $starting_date = new DateTime($start_date_ymd);
+  $ending_date = new DateTime($end_date_ymd);
+  while ($starting_date <= $ending_date) {
     $db = \Drupal::database();
     $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
     $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
 
     // array initialized with "library wide" location Id - 9999
-    $queryLocationIds = array(9999);
+    $query_location_ids = array(9999);
 
     if ($location < 1000) { // must be a branch location so we need to get all the pickup location ids for that branch
-      $branchLocationIds = arborcat_get_pickup_locations($location);
-      array_push($queryLocationIds, ...$branchLocationIds);
+      $branch_location_ids = arborcat_get_pickup_locations($location);
+      array_push($query_location_ids, ...$branch_location_ids);
     }
 
     // always push the location passed in because the exclusion record may contain
-    array_push($queryLocationIds, $location);
-    $query->condition('locationId', $queryLocationIds, 'IN');
-    $query->condition('dateStart', date_format($date1, 'Y-m-d'), '<=');
-    $query->condition('dateEnd', date_format($date1, 'Y-m-d'), '>=');
+    array_push($query_location_ids, $location);
+    $query->condition('locationId', $query_location_ids, 'IN');
+    $query->condition('dateStart', date_format($starting_date, 'Y-m-d'), '<=');
+    $query->condition('dateEnd', date_format($starting_date, 'Y-m-d'), '>=');
     // sort the exclusions that match the date by location in descending order so library-wide (9999) closures are first in the array of found exclusions
     $query->orderBy('locationId', 'DESC');
 
     $result = $query->execute();
-    $exclusionData = $result->fetchAll();
+    $exclusion_data_array = $result->fetchAll();
 
     $exclusion_data = null;
-    if (count($exclusionData) > 0) {
-      $exclusion_data = $exclusionData[0];
+    if (count($exclusion_data) > 0) {
+      $exclusion_data = $exclusion_data_array[0];
     }
     // format the display string for the date that will be shown in the pickup dates dropdown menu
-    $theDate_mdY = $date1->format('M. j');
-    $day_of_week = intval($date1->format('w'));
-    $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
-    $datestring = $dayOfWeek . ', ' . $theDate_mdY;
-    $datestr_Ymd = $date1->format('Y-m-d');
-    $pickupdates[$datestr_Ymd] = ['display_date_string' => $datestring, 'date_exclusion_data' => $exclusion_data];
+    $date_month_day = $starting_date->format('M. j');
+    $day_of_week = intval($starting_date->format('w'));
+    $day_of_week_string = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
+    $day_month_daynum = $day_of_week_string . ', ' . $date_month_day;
+    $datestr_Ymd = $starting_date->format('Y-m-d');
+    $pickup_dates[$datestr_Ymd] = ['display_date_string' => $day_month_daynum, 'date_exclusion_data' => $exclusion_data];
 
-    $date1->modify('+1 day');
+    $starting_date->modify('+1 day');
   }
 
-  return $pickupdates;
+  return $pickup_dates;
 }
 
- function arborcat_load_exclusion_data($location, $startDateYmd, $endDateYmd) {
- // Load exclusion dates for date range defined in the two params from the table: arborcat_pickup_location_exclusion
-  // For all branches (locationId=9999) 
-  $db = \Drupal::database();
-  $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
-  $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
-  
-  $andGroup1 = $query->andConditionGroup()
-    ->condition('dateStart', $startDateYmd, '<')
-    ->condition('dateEnd', $endDateYmd, '>');
-
-  $orGroup1 = $query->orConditionGroup()
-    ->condition('dateStart', [$startDateYmd, $endDateYmd], 'BETWEEN')
-    ->condition('dateEnd', [$startDateYmd, $endDateYmd], 'BETWEEN')
-    ->condition($andGroup1);
-  
-  $query->condition($orGroup1);
-
-  // array initialized with "library wide" location Id - 9999
-  $queryLocationIds = array(9999);
-
-  if ($location < 1000) { // must be a branch location so we need to get all the pickup location ids for that branch
-    $branchLocationIds = arborcat_get_pickup_locations($location);
-    array_push($queryLocationIds, ...$branchLocationIds);
-  }
-  // always push the location passed in because the exclusion record may contain
-  array_push($queryLocationIds, $location);
-  $query->condition('locationId', $queryLocationIds, 'IN');
-
-  $result = $query->execute();
-  $exclusionData = $result->fetchAll();
-  return $exclusionData;
-}
-
-function arborcat_get_pickup_locations($branchLocationId) {
+function arborcat_get_pickup_locations($branch_location_id) {
   $db = \Drupal::database();
   $query = $db->select('arborcat_pickup_location', 'apl');
   $query->fields('apl', ['locationId']);
-  $query->condition('branchLocationId', $branchLocationId, '=');
+  $query->condition('branchLocationId', $branch_location_id, '=');
   $result = $query->execute();
-  $locationIds = $result->fetchCol();
+  $location_ids = $result->fetchCol();
 
-  return $locationIds;
+  return $location_ids;
 }
 
-function arborcat_calculate_pickup_dates($branchLocation, $exclusionData) {
-  $startingDayOffset = 1; // Load these from ArborCat Settings?
-  $numPickupDays = 7;     // Load these from ArborCat Settings?
-  $startingDay = new DateTime('+' . $startingDayOffset . ' day');
-  $startingDayPlusPickupDays = clone $startingDay;
-  $startingDayPlusPickupDays->modify('+' . $numPickupDays . ' days');
-
-  $pickupLocations = arborcat_get_pickup_locations($branchLocation);
-    // now loop for x days and create a date string for each day, preceded with the day name
-  // create a human friendly version - 'formattedDate' for display purposes in the UI
-  // and a basic verson 'date' for use in date db queries
-  $interval = \DateInterval::createFromDateString('1 day');
-  $period = new \DatePeriod($startingDay, $interval, $startingDayPlusPickupDays);
-
-  $pickupdates = [];
-
-  foreach ($period as $adate) {
-    $adatestr_Ymd = $adate->format('Y-m-d');
-    $pickupLocations = arborcat_get_pickup_locations($branchLocation);
-    // Loop through the exclusion data  - check whether the date is between the start and end dates.
-    // If so, check whether the exclusion is branch wide or location specific 
-    // (ie. one of the vestibules or lockers at a branch and others are available on that date)
-
-    foreach($exclusionData as $exclusion) {
-      $exclusionStart = new DateTime($exclusion->dateStart);
-      $exclusionEnd = new DateTime($exclusion->dateEnd);
-      $addthisdate = FALSE;
- 
-      if ($adatestr_Ymd >= $exclusion->dateStart && $adatestr_Ymd <= $exclusion->dateEnd) {
-        // need to check if actually exclusion
-        if ($exclusion->locationId < 1000) { // this is branch-wide        
-          $pickupLocations = [];
-        }
-        else {
-          $offset = array_search($exclusion->locationId, $pickupLocations);
-          if (FALSE != $offset) {
-            array_splice($pickupLocations, $offset);
-          }
-        }
-      }
-    }
-    // if there are no locations left after looping through the exclusion data, then we can mark the date as an exclusion date
-    if (count($pickupLocations) > 0) {
-      $theDate_mdY = $adate->format('M. j');
-      $day_of_week = intval($adate->format('w'));
-      $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
-      $datestring = $dayOfWeek . ', ' . $theDate_mdY;
-      $datestr_Ymd = $adate->format('Y-m-d');
-      $pickupdates[$datestr_Ymd] = $datestring;
-    }
-  }
-
-  return $pickupdates;
-}
 

--- a/arborcat.module
+++ b/arborcat.module
@@ -453,20 +453,34 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
   return $resultMessage;
 }
 
- function arborcat_load_exclusion_data($loadScope, $startDateYmd, $endDateYmd) {
-   dblog('ENTERED arborcat_load_exclusion_data', $loadScope, '|', $startDateYmd, '|',  $endDateYmd);
-// Load exclusion dates for all branches (locationId=9999) for the next $numPickup Days from the table: arborcat_pickup_location_exclusion
+ function arborcat_load_exclusion_data($location, $startDateYmd, $endDateYmd) {
+   dblog("\n\n", 'ENTERED arborcat_load_exclusion_data, location = ', $location, '|', $startDateYmd, '|',  $endDateYmd);
+  // Load exclusion dates for date range defined in the two params from the table: arborcat_pickup_location_exclusion
+  // For all branches (locationId=9999) 
   $db = \Drupal::database();
   $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
   $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
   $query->condition('dateStart', $startDateYmd, '>=');
-  $query->condition('dateStart', $endDateYmd, '<=');
-  if ('DISTRICT_WIDE' == $loadScope) {
-    $query->condition('locationId', 9999, '=');
+  // dateEnd could be null or a real date - need to form query for one OR the other
+  $orGroup = $query->orConditionGroup()
+    ->condition('dateEnd', $endDateYmd, '<=')
+    ->condition('dateEnd', null, '=');
+  $query->condition($orGroup);
+
+  // array initialized with "library wide" location Id - 9999
+  $queryLocationIds = array(9999);
+
+  if ($location < 1000) { // must be a branch location so we need to get all the pickup location ids for that branch
+    $branchLocationIds = arborcat_get_pickup_locations($location);
+    array_push($queryLocationIds, ...$branchLocationIds);
   }
-  else {
-    $query->condition('locationId', 9999, '<>');
-  }
+
+  // always push the location passed in because the exclusion record may contain
+  array_push($queryLocationIds, $location);
+  
+  dblog('arborcat_load_exclusion_data: BEFORE ADDING IN condition, $queryLocationIds = ', $queryLocationIds);
+  $query->condition('locationId', $queryLocationIds, 'IN');
+ 
   $result = $query->execute();
   $exclusionData = $result->fetchAll();
   dblog('arborcat_load_exclusion_data: RETURNING exclusionData = ', $exclusionData);
@@ -474,62 +488,16 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
   return $exclusionData;
 }
 
-function arborcat_process_exclusion_data($exclusionData) {
-  $exclusionDates = [];
-  
-  foreach ($exclusionData as $exclusionDataRec) {
-    $start = $exclusionDataRec->dateStart;
-    $end = $exclusionDataRec->dateEnd;
-    if ($end == null) { //  single day, so set $end to $start
-      $end = $start;
-    }
-    $start = new DateTime($start);
-    $end = new DateTime($end);
-    $end->setTime(0, 0, 1);     // Make ending dateTime at least 1 second greater than the start dateTime.
-    // iterate between startDate and endDate creating simple Date strings of the format: 'Jun. 20'
-    $interval = \DateInterval::createFromDateString('1 day');
-    $period = new \DatePeriod($start, $interval, $end);
-    foreach ($period as $date) {
-      array_push($exclusionDates, $date->format('Y-m-d'));
-   }
-  }
+function arborcat_get_pickup_locations($branchLocationId) {
+  $db = \Drupal::database();
+  $query = $db->select('arborcat_pickup_location', 'apl');
+  $query->fields('apl', ['locationId']);
+  $query->condition('branchLocationId', $branchLocationId, '=');
+  $result = $query->execute();
+  $locationIds = $result->fetchCol();
 
-  return $exclusionDates;
-}
-
-function arborcat_calculate_pickup_dates($exclusionData) { 
-  dblog('arborcat_calculate_pickup_dates: ENTERED $exclusionData =', $exclusionData);
-  $startingDayOffset = 1; // Load these from ArborCat Settings?
-  $numPickupDays = 7;     // Load these from ArborCat Settings?
-  $startingDay = new DateTime('+' . $startingDayOffset . ' day');
-  $startingDayPlusPickupDays = clone $startingDay;
-  $startingDayPlusPickupDays->modify('+' . $numPickupDays . ' days');
-
-  if (NULL == $exclusionData) {
-    dblog('arborcat_calculate_pickup_dates: $exclusionData == NULL');
-    $exclusionData = arborcat_load_exclusion_data('DISTRICT_WIDE', $startingDay->format('Y-m-d'), $startingDayPlusPickupDays->format('Y-m-d'));
-  }
-  dblog('arborcat_calculate_pickup_dates: AFTER NULL CHECK $exclusionData =', $exclusionData);
-  $exclusionDates = arborcat_process_exclusion_data($exclusionData);
-
-  // now loop for x days and create a date string for each day, preceded with the day name
-  // create a human friendly version - 'formattedDate' for display purposes in the UI
-  // and a basic verson 'date' for use in date db queries
-  $interval = \DateInterval::createFromDateString('1 day');
-  $period = new \DatePeriod($startingDay, $interval, $startingDayPlusPickupDays);
-
-  $pickupdates = [];
-  foreach ($period as $date) {
-    $theDate_mdY = $date->format('M. j');
-    $day_of_week = intval($date->format('w'));
-    $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
-    $datestring = $dayOfWeek . ', ' . $theDate_mdY;
-    $datestr_Ymd = $date->format('Y-m-d');
-    if (!in_array($datestr_Ymd, $exclusionDates)) {
-      $pickupdates[$datestr_Ymd] = $datestring;
-    }
-  }
-  return $pickupdates;
+  dblog('arborcat_get_pickup_locations: RETURNING pickup locationIds = ', json_encode($locationIds));
+  return $locationIds;
 }
 
 function dblog(...$thingsToLog) {

--- a/arborcat.module
+++ b/arborcat.module
@@ -454,18 +454,14 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
 }
 
  function arborcat_load_exclusion_data($location, $startDateYmd, $endDateYmd) {
-   dblog("\n\n", 'ENTERED arborcat_load_exclusion_data, location = ', $location, '|', $startDateYmd, '|',  $endDateYmd);
-  // Load exclusion dates for date range defined in the two params from the table: arborcat_pickup_location_exclusion
+ // Load exclusion dates for date range defined in the two params from the table: arborcat_pickup_location_exclusion
   // For all branches (locationId=9999) 
   $db = \Drupal::database();
   $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
   $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
+  
   $query->condition('dateStart', $startDateYmd, '>=');
-  // dateEnd could be null or a real date - need to form query for one OR the other
-  $orGroup = $query->orConditionGroup()
-    ->condition('dateEnd', $endDateYmd, '<=')
-    ->condition('dateEnd', null, '=');
-  $query->condition($orGroup);
+  $query->condition('dateEnd', $endDateYmd, '<=');
 
   // array initialized with "library wide" location Id - 9999
   $queryLocationIds = array(9999);
@@ -477,13 +473,10 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
 
   // always push the location passed in because the exclusion record may contain
   array_push($queryLocationIds, $location);
-  
-  dblog('arborcat_load_exclusion_data: BEFORE ADDING IN condition, $queryLocationIds = ', $queryLocationIds);
   $query->condition('locationId', $queryLocationIds, 'IN');
- 
+
   $result = $query->execute();
   $exclusionData = $result->fetchAll();
-  dblog('arborcat_load_exclusion_data: RETURNING exclusionData = ', $exclusionData);
 
   return $exclusionData;
 }
@@ -496,25 +489,60 @@ function arborcat_get_pickup_locations($branchLocationId) {
   $result = $query->execute();
   $locationIds = $result->fetchCol();
 
-  dblog('arborcat_get_pickup_locations: RETURNING pickup locationIds = ', json_encode($locationIds));
   return $locationIds;
 }
 
-function dblog(...$thingsToLog) {
-  $lineToLog = '';
-  foreach ($thingsToLog as $item) {
-    //$lineToLog = $lineToLog . ' ' . print_r($item, true);
-    $item2 = $item;
-    if (is_array($item)) {
-      $item2 = ' ARRAY: ' . json_encode($item);
-    } elseif (is_object($item)) {
-      $item2 = 'OBJECT: ' . json_encode($item);
+function arborcat_calculate_pickup_dates($branchLocation, $exclusionData) {
+  $startingDayOffset = 1; // Load these from ArborCat Settings?
+  $numPickupDays = 7;     // Load these from ArborCat Settings?
+  $startingDay = new DateTime('+' . $startingDayOffset . ' day');
+  $startingDayPlusPickupDays = clone $startingDay;
+  $startingDayPlusPickupDays->modify('+' . $numPickupDays . ' days');
+
+  $pickupLocations = arborcat_get_pickup_locations($branchLocation);
+    // now loop for x days and create a date string for each day, preceded with the day name
+  // create a human friendly version - 'formattedDate' for display purposes in the UI
+  // and a basic verson 'date' for use in date db queries
+  $interval = \DateInterval::createFromDateString('1 day');
+  $period = new \DatePeriod($startingDay, $interval, $startingDayPlusPickupDays);
+
+  $pickupdates = [];
+
+  foreach ($period as $adate) {
+    $adatestr_Ymd = $adate->format('Y-m-d');
+    $pickupLocations = arborcat_get_pickup_locations($branchLocation);
+    // Loop through the exclusion data  - check whether the date is between the start and end dates.
+    // If so, check whether the exclusion is branch wide or location specific 
+    // (ie. one of the vestibules or lockers at a branch and others are available on that date)
+
+    foreach($exclusionData as $exclusion) {
+      $exclusionStart = new DateTime($exclusion->dateStart);
+      $exclusionEnd = new DateTime($exclusion->dateEnd);
+      $addthisdate = FALSE;
+ 
+      if ($adatestr_Ymd >= $exclusion->dateStart && $adatestr_Ymd <= $exclusion->dateEnd) {
+        // need to check if actually exclusion
+        if ($exclusion->locationId < 1000) { // this is branch-wide        
+          $pickupLocations = [];
+        }
+        else {
+          $offset = array_search($exclusion->locationId, $pickupLocations);
+          if (FALSE != $offset) {
+            array_splice($pickupLocations, $offset);
+          }
+        }
+      }
     }
-    $lineToLog .= ' ' . $item2;
+    // if there are no locations left after looping through the exclusion data, then we can mark the date as an exclusion date
+    if (count($pickupLocations) > 0) {
+      $theDate_mdY = $adate->format('M. j');
+      $day_of_week = intval($adate->format('w'));
+      $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
+      $datestring = $dayOfWeek . ', ' . $theDate_mdY;
+      $datestr_Ymd = $adate->format('Y-m-d');
+      $pickupdates[$datestr_Ymd] = $datestring;
+    }
   }
-  // prepend date/time onto log line
-  $nowDateTime = new DrupalDateTime();
-  $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
-  $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
-  error_log($completeLine, 3, "LWKLWK.log");
+
+  return $pickupdates;
 }

--- a/arborcat.module
+++ b/arborcat.module
@@ -453,21 +453,41 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
   return $resultMessage;
 }
 
+function processExclusionData($exclusionData) {
+  $exclusionDates = [];
+  foreach ($exclusionData as $exclusionDataRec) {
+    $start = $exclusionDataRec->dateStart;
+    $end = $exclusionDataRec->dateEnd;
+    if ($end == null) { //  single day, so set $end to $start
+      $end = $start;
+    }
+    $start = new DateTime($start);
+    $end = new DateTime($end);
+    $end->setTime(0, 0, 1);     // Make ending dateTime at least 1 second greater than the start dateTime.
+    // iterate between startDate and endDate creating simple Date strings of the format: 'Jun. 20'
+    $interval = \DateInterval::createFromDateString('1 day');
+    $period = new \DatePeriod($start, $interval, $end);
+    foreach ($period as $date) {
+      array_push($exclusionDates, $date->format('M. j'));
+   }
+  }
+
+  return $exclusionDates;
+}
+
 function arborcat_calculate_pickup_dates() {
   $arrayOfDates = [];
  
   $startingDayOffset = 1; // Load these from ArborCat Settings?
-  $numPickupDays = 90;     // Load these from ArborCat Settings?
+  $numPickupDays = 7;     // Load these from ArborCat Settings?
   $startingDay = new DateTime('+' . $startingDayOffset . ' day');
   $startingDayPlusPickup = new DateTime('+' . $numPickupDays . ' days');
-  dblog('arborcat_calculate_pickup_dates:                startDate =', $startingDay->format('Y-m-d'));
-  dblog('arborcat_calculate_pickup_dates: startingDayPlusPickup =', $startingDayPlusPickup->format('Y-m-d'));
 
   // now loop for x days and create a date string for each day, preceded with the day name
   // create a human friendly version - 'formattedDate' for display purposes in the UI
   // and a basic verson 'date' for use in date db queries
 
-  // Load exclusion dates for the next $numPickup Days from the table: arborcat_pickup_location_exclusion
+  // Load exclusion dates for all branches (locationId=9999) for the next $numPickup Days from the table: arborcat_pickup_location_exclusion
   $db = \Drupal::database();
   $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
   $query->fields('aple', ['locationId', 'dateStart', 'dateEnd']);
@@ -476,15 +496,9 @@ function arborcat_calculate_pickup_dates() {
   $query->condition('locationId', 9999, '=');
   $result = $query->execute();
   $exclusionData = $result->fetchAll();
-  dblog('exclusionData: ', json_encode($exclusionData));
 
-  // this is not ideal whatsoever and just quick way to address unavailable / closure dates
-  $date_exclude = [
-          'Jun. 20',
-          'Jun. 21',
-          'Jul. 4',
-          'Sep. 7'
-      ];
+  $date_exclude = processExclusionData($exclusionData);
+
   for ($x=0; $x < $numPickupDays; $x++) {
     $theDate_mdY = $startingDay->format('M. j');
     $day_of_week = intval($startingDay->format('w'));
@@ -501,25 +515,4 @@ function arborcat_calculate_pickup_dates() {
   }
 
   return $arrayOfDates;
-}
-
-function dblog(...$thingsToLog)
-{
-  $lineToLog = '';
-  foreach ($thingsToLog as $item) {
-    //$lineToLog = $lineToLog . ' ' . print_r($item, true);
-    $item2 = $item;
-    if (is_array($item)) {
-      $item2 = ' ARRAY: ' . json_encode($item);
-    }
-    else if (is_object($item)) {
-      $item2 = 'OBJECT: ' . json_encode($item);
-    }
-    $lineToLog .= ' ' . $item2;
-  }
-  // prepend date/time onto log line
-  $nowDateTime = new DrupalDateTime();
-  $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
-  $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
-  error_log($completeLine, 3, "LWKLWK.log");
 }

--- a/arborcat.module
+++ b/arborcat.module
@@ -477,7 +477,7 @@ function processExclusionData($exclusionData) {
 
 function arborcat_calculate_pickup_dates() { 
   $startingDayOffset = 1; // Load these from ArborCat Settings?
-  $numPickupDays = 90;     // Load these from ArborCat Settings?
+  $numPickupDays = 7;     // Load these from ArborCat Settings?
   $startingDay = new DateTime('+' . $startingDayOffset . ' day');
   $startingDayPlusPickupDays = clone $startingDay;
   $startingDayPlusPickupDays->modify('+' . $numPickupDays . ' days');

--- a/arborcat.module
+++ b/arborcat.module
@@ -351,35 +351,53 @@ function arborcat_create_pickup_request_record($pickup_request_type, $customId, 
   }
 }
 
-function barcodeFromPatronId($patronId) {
+function barcode_from_patron_id($patronId) {
   $api_key = \Drupal::config('arborcat.settings')->get('api_key');
   $api_url = \Drupal::config('arborcat.settings')->get('api_url');
   $guzzle = \Drupal::httpClient();
   $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
-  $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+
+  try {
+    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+  } 
+  catch (Exception $e) {
+
+    return "";
+  }
   if ($json) {
     $barcode =  $json->evg_user->card->barcode;
 
     return $barcode;
-  } else {
+  } 
+  else {
+  
     return "";
   }
 }
 
-function patronIdFromBarcode($barcode) {
+function patron_id_from_barcode($barcode) {
   $api_key = \Drupal::config('arborcat.settings')->get('api_key');
   $api_url = \Drupal::config('arborcat.settings')->get('api_url');
   $guzzle = \Drupal::httpClient();
   $requestURL = "$api_url/patron?apikey=$api_key&barcode=$barcode";
-  $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+    try {
+      $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+    } 
+    catch (Exception $e) {
+
+    return "";
+  }
   if ($json) {
     $patronId =  $json->pid;
 
     return $patronId;
-  } else {
+  } 
+  else {
+    
     return "";
   }
 }
+
   
 function arborcat_custom_pickup_request($pickup_request_type, $customPickupRequestId) {
   $resultMessage = '';
@@ -408,7 +426,7 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
 
     if (count($assocResults) > 0) {
       $barcode = $assocResults['barcode'];
-      $patronId = (strlen($barcode) == 14) ? patronIdFromBarcode($barcode) : NULL;
+      $patronId = (strlen($barcode) == 14) ? patron_id_from_barcode($barcode) : NULL;
       $branchNameArray = explode(" ", $assocResults['delivery_method']);
       if ($branchNameArray[0] == 'Mail') {  // Mail to Patron option - no pickup request should be created
         $resultMessage = 'SUCCESS';
@@ -453,6 +471,55 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
   return $resultMessage;
 }
 
+function arborcat_get_pickup_dates($location, $startDateYmd, $endDateYmd) {
+  // Load exclusion dates for date range defined in the two params from the table: arborcat_pickup_location_exclusion
+  // For all branches (locationId=9999)
+  $pickupdates = [];
+  // Loop through each date, 1 day at a time, checking if there is an exclusion.
+  $date1 = new DateTime($startDateYmd);
+  $endingDate = new DateTime($endDateYmd);
+  while ($date1 <= $endingDate) {
+    $db = \Drupal::database();
+    $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
+    $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
+
+    // array initialized with "library wide" location Id - 9999
+    $queryLocationIds = array(9999);
+
+    if ($location < 1000) { // must be a branch location so we need to get all the pickup location ids for that branch
+      $branchLocationIds = arborcat_get_pickup_locations($location);
+      array_push($queryLocationIds, ...$branchLocationIds);
+    }
+
+    // always push the location passed in because the exclusion record may contain
+    array_push($queryLocationIds, $location);
+    $query->condition('locationId', $queryLocationIds, 'IN');
+    $query->condition('dateStart', date_format($date1, 'Y-m-d'), '<=');
+    $query->condition('dateEnd', date_format($date1, 'Y-m-d'), '>=');
+    // sort the exclusions that match the date by location in descending order so library-wide (9999) closures are first in the array of found exclusions
+    $query->orderBy('locationId', 'DESC');
+
+    $result = $query->execute();
+    $exclusionData = $result->fetchAll();
+
+    $exclusion_data = null;
+    if (count($exclusionData) > 0) {
+      $exclusion_data = $exclusionData[0];
+    }
+    // format the display string for the date that will be shown in the pickup dates dropdown menu
+    $theDate_mdY = $date1->format('M. j');
+    $day_of_week = intval($date1->format('w'));
+    $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
+    $datestring = $dayOfWeek . ', ' . $theDate_mdY;
+    $datestr_Ymd = $date1->format('Y-m-d');
+    $pickupdates[$datestr_Ymd] = ['display_date_string' => $datestring, 'date_exclusion_data' => $exclusion_data];
+
+    $date1->modify('+1 day');
+  }
+
+  return $pickupdates;
+}
+
  function arborcat_load_exclusion_data($location, $startDateYmd, $endDateYmd) {
  // Load exclusion dates for date range defined in the two params from the table: arborcat_pickup_location_exclusion
   // For all branches (locationId=9999) 
@@ -460,8 +527,16 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
   $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
   $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
   
-  $query->condition('dateStart', $startDateYmd, '>=');
-  $query->condition('dateEnd', $endDateYmd, '<=');
+  $andGroup1 = $query->andConditionGroup()
+    ->condition('dateStart', $startDateYmd, '<')
+    ->condition('dateEnd', $endDateYmd, '>');
+
+  $orGroup1 = $query->orConditionGroup()
+    ->condition('dateStart', [$startDateYmd, $endDateYmd], 'BETWEEN')
+    ->condition('dateEnd', [$startDateYmd, $endDateYmd], 'BETWEEN')
+    ->condition($andGroup1);
+  
+  $query->condition($orGroup1);
 
   // array initialized with "library wide" location Id - 9999
   $queryLocationIds = array(9999);
@@ -470,14 +545,12 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
     $branchLocationIds = arborcat_get_pickup_locations($location);
     array_push($queryLocationIds, ...$branchLocationIds);
   }
-
   // always push the location passed in because the exclusion record may contain
   array_push($queryLocationIds, $location);
   $query->condition('locationId', $queryLocationIds, 'IN');
 
   $result = $query->execute();
   $exclusionData = $result->fetchAll();
-
   return $exclusionData;
 }
 
@@ -546,3 +619,4 @@ function arborcat_calculate_pickup_dates($branchLocation, $exclusionData) {
 
   return $pickupdates;
 }
+

--- a/arborcat.module
+++ b/arborcat.module
@@ -503,7 +503,7 @@ function arborcat_get_pickup_dates($location, $start_date_ymd, $end_date_ymd) {
     $exclusion_data_array = $result->fetchAll();
 
     $exclusion_data = null;
-    if (count($exclusion_data) > 0) {
+    if (count($exclusion_data_array) > 0) {
       $exclusion_data = $exclusion_data_array[0];
     }
     // format the display string for the date that will be shown in the pickup dates dropdown menu

--- a/arborcat.module
+++ b/arborcat.module
@@ -61,12 +61,15 @@ function arborcat_theme($existing, $type, $theme, $path) {
 }
 
 /**
+ * Pass variables to front-end JS
  * @param $variables
  */
 function arborcat_preprocess_page(&$variables) {
   // get the max locker item check  from ArborCat module settings
   $max_locker_items = \Drupal::config('arborcat.settings')->get('max_locker_items_check');
   $variables['#attached']['drupalSettings']['arborcat']['max_locker_items_check'] = $max_locker_items;
+  $exclusion_marker_string = \Drupal::config('arborcat.settings')->get('exclusion_marker_string');
+  $variables['#attached']['drupalSettings']['arborcat']['exclusion_marker_string'] = $exclusion_marker_string;
 }
 
 function arborcat_generate_api_key() {
@@ -530,5 +533,4 @@ function arborcat_get_pickup_locations($branch_location_id) {
 
   return $location_ids;
 }
-
 

--- a/arborcat.module
+++ b/arborcat.module
@@ -95,361 +95,420 @@ function arborcat_patron_fines_expired($fines, $patron) {
 }
 
 //check if a hold is eligible for a locker based on material type
-  function arborcat_eligible_for_locker($hold) {
-    if ($hold['material'] == "Oversize") {
-      return FALSE;
-    } else {
-      return TRUE;
-    }
+function arborcat_eligible_for_locker($hold) {
+  if ($hold['material'] == "Oversize") {
+    return FALSE;
+  } else {
+    return TRUE;
   }
+}
 
-  //check if there are lockers available to place holds into
-  function arborcat_lockers_available($branch) {
-    $mess = \Drupal::messenger();
-    $available=FALSE;
-    if (stripos($branch, 'Malletts')!==FALSE) {
-      $locker_server = 'mcblockers';
-    } elseif (stripos($branch, 'Pittsfield')!==FALSE) {
-      $locker_server = 'ptslockers';
+//check if there are lockers available to place holds into
+function arborcat_lockers_available($branch) {
+  $mess = \Drupal::messenger();
+  $available=FALSE;
+  if (stripos($branch, 'Malletts')!==FALSE) {
+    $locker_server = 'mcblockers';
+  } elseif (stripos($branch, 'Pittsfield')!==FALSE) {
+    $locker_server = 'ptslockers';
+  }
+  if ($locker_server=='ptslockers') {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('pts_lockers'));
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
+    $result = curl_exec($ch);
+
+    $simpleXML = simplexml_load_string($result);
+    $i=1;
+    $s = $simpleXML->doors->children();
+    if ($s->assign1==0&$s->assign2==0&$s->assign3==0&$s->assign4==0) {
+      $available = FALSE;
+    } elseif ($s->assign1!==0||$s->assign2!==0||$s->assign3!==0||$s->assign4!==0) {
+      $available = TRUE;
     }
-    if ($locker_server=='ptslockers') {
-      $ch = curl_init();
-      curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('pts_lockers'));
-      curl_setopt($ch, CURLOPT_HEADER, 0);
-      curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-      curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
-      $result = curl_exec($ch);
-
-      $simpleXML = simplexml_load_string($result);
-      $i=1;
-      $s = $simpleXML->doors->children();
-      if ($s->assign1==0&$s->assign2==0&$s->assign3==0&$s->assign4==0) {
-        $available = FALSE;
-      } elseif ($s->assign1!==0||$s->assign2!==0||$s->assign3!==0||$s->assign4!==0) {
+  } elseif ($locker_server=='mcblockers') {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('mcb_lockers'));
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
+    $result = curl_exec($ch);
+    if ($result != NULL) {
+      preg_match_all('%name="web_patroninserted_door.*?value="([\d]+?)"%s', $result, $matches);
+      if ($matches[1][0]>0) {
         $available = TRUE;
       }
-    } elseif ($locker_server=='mcblockers') {
-      $ch = curl_init();
-      curl_setopt($ch, CURLOPT_URL, \Drupal::config('arborcat.settings')->get('mcb_lockers'));
-      curl_setopt($ch, CURLOPT_HEADER, 0);
-      curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-      curl_setopt($ch, CURLOPT_USERPWD, \Drupal::config('arborcat.settings')->get('lockers_pass'));
-      $result = curl_exec($ch);
-      if ($result != NULL) {
-        preg_match_all('%name="web_patroninserted_door.*?value="([\d]+?)"%s', $result, $matches);
-        if ($matches[1][0]>0) {
-          $available = TRUE;
-        }
-      }
     }
-
-    return $available;
   }
 
-  /*
-   * returns a list of request pickup locations.
-   * If a branch location is passed in, that a filtered list of pickup locations is returned
-   */
-  function arborcat_pickup_locations($destLocation = NULL, $lookupName = NULL, $frontBack = NULL, $lobbyOnly = NULL) {
-    $db = \Drupal::database();
-    $query = $db->select('arborcat_pickup_location', 'apl')
-      ->fields('apl', ['locationId', 'branchLocationId', 'timePeriod', 'timePeriodStart', 'timePeriodEnd', 'maxLockers', 'locationName', 'locationDescription'])
-      ->condition('active', 1, "=");
+  return $available;
+}
 
-    // if lookupName supplied, get lib locations and lookup the branch number.
-    // Then set the parameter $destlocation to the branch number. If set, the location filter will be applied
-    if (strlen($lookupName) > 0) {
-      $guzzle = \Drupal::httpClient();
-      $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-      $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
-      foreach ($locations as $key => $value) {
-        if (strpos($value, $lookupName) !== FALSE) {
-          $destLocation = $key;
+/*
+  * returns a list of request pickup locations.
+  * If a branch location is passed in, that a filtered list of pickup locations is returned
+  */
+function arborcat_pickup_locations($destLocation = NULL, $lookupName = NULL, $frontBack = NULL, $lobbyOnly = NULL) {
+  $db = \Drupal::database();
+  $query = $db->select('arborcat_pickup_location', 'apl')
+    ->fields('apl', ['locationId', 'branchLocationId', 'timePeriod', 'timePeriodStart', 'timePeriodEnd', 'maxLockers', 'locationName', 'locationDescription'])
+    ->condition('active', 1, "=");
 
-          break;
-        }
-      }
-    }
-    // add in a condition if a location is supplied to filter on
-    if (3 == strlen($destLocation)) {
-      $query->condition('branchLocationId', (int) $destLocation, '=');
-    }
-    // add in a condition if a lobbyOnly is supplied to filter on
-    if (NULL != $lobbyOnly) {
-      $query->condition('maxLockers', 0, '=');
-    }
-    // add in a condition for 'Front' versus 'Back' in the location Name
-    if (NULL != $frontBack) {
-      $query->condition('locationName', "%" . $db->escapeLike($frontBack) . "%", 'like');
-    }
-    $result = $query->execute();
-    $pickupLocationRecords = $result->fetchAll();
-
-    return $pickupLocationRecords;
-  }
-
-  /*
-   * returns an array of active locker pickup locations.
-   */
-  function arborcat_locker_pickup_locations() {
-    $locations = [];
-    $db = \Drupal::database();
-    $query = $db->select('arborcat_pickup_location', 'apl')
-        ->fields('apl', ['locationId'])
-        ->condition('maxLockers', 0, '>')
-        ->condition('active', 1, '=')
-        ->execute();
-    $locations = array_values($query->fetchCol());
-
-    return $locations;
-  }
-
-
-   /*
-   * Checks the availability of a locker fo the specified date and timePeriod.
-   * If a branch location is passed in, that a filtered list of pickup locations is returned
-   */
-  function arborcat_check_locker_availability($queryDate, $locationObject, $patronId) {
-    $availableLockers = 0;
-    // Query current arborcat_patron_pickup_request records for the date and timePeriod to get inuse count
-    // fields pickupDate & timeSlot
-    $db = \Drupal::database();
-    $pickup_point = $locationObject->locationId;
-
-    $query = $db->select('arborcat_patron_pickup_request', 'appr')
-      ->fields('appr', ['patronId'])
-      ->condition('pickupDate', $queryDate)
-      ->condition('pickupLocation', $pickup_point, '=')
-      ->groupBy('patronId');
-    $results = $query->execute()->fetchCol();
- 
-    $lockersInUse = count($results);
-    $availableLockers = $locationObject->maxLockers - $lockersInUse;
-    $returnval = FALSE;
-    // check whether this patron already has a pickup appointment already scheduled for this locker at this time. OR whether there are available lockers at this time
-    if (in_array($patronId, $results) || $availableLockers > 0) {
-      $returnval = TRUE;
-    }
-
-    return ($returnval);
-  }
-
-  function arborcat_load_patron_eligible_holds($patron_barcode, $requestLocation=NULL) {
+  // if lookupName supplied, get lib locations and lookup the branch number.
+  // Then set the parameter $destlocation to the branch number. If set, the location filter will be applied
+  if (strlen($lookupName) > 0) {
     $guzzle = \Drupal::httpClient();
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-    $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
-    $selfCheckApi_key .= '-' .  $patron_barcode;
+    $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
+    foreach ($locations as $key => $value) {
+      if (strpos($value, $lookupName) !== FALSE) {
+        $destLocation = $key;
 
-    try {
-      $patron_holds = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/holds")->getBody()->getContents(), TRUE);
-
-      // For debugging LWK
-      // $jsonData = file_get_contents('10005279_21621034452183_holds.txt');
-      // $patron_holds = json_decode($jsonData, TRUE);
-    } catch (Exception $e) {
-      $eligible_holds['error'] = 'Info not found';
-
-      return $eligible_holds;
-    }
-    $eligible_holds = [];
-    //start at 1 to avoid issue with eligible holds array not being zero-based
-    $i=1;
-
-    $mel_mappings = [
-          113 => 102,
-          114 => 103,
-          115 => 104,
-          116 => 105,
-          117 => 106
-    ];
-
-    $db = \Drupal::database();
-    if (count($patron_holds)) {
-      foreach ($patron_holds as $hold) {
-        if ($hold['status'] == 'Ready for Pickup') {
-          // check if there is a requestLocation to filter on. If not, set $includeLocationBoolean to TRUE, otherwise perform check for location match
-          $includeLocationBoolean = ($requestLocation == NULL) ? TRUE : ($hold['hold']['pickup_lib'] == $requestLocation);
-          if ($includeLocationBoolean || isset($mel_mappings[$hold['hold']['pickup_lib']])) {
-            // if pickup appt already set, don't display item
-            $pickup_req_exists = $db->query("SELECT * from arborcat_patron_pickup_request WHERE requestId = :hid", [':hid' => $hold['id']])->fetch();
-            if (isset($pickup_req_exists->id)) {
-              continue;
-            }
-            $shelf_expire = date('Y-m-d', strtotime($hold['hold']['shelf_expire_time']));
-            if (arborcat_eligible_for_locker($hold) && $shelf_expire >= date('Y-m-d')) {
-              $eligible_holds[$i] = [
-                              'Title' => $hold['title'],
-                              'Status' => $hold['status'],
-                              'PickupLoc' => $hold['pickup'],
-                              'pickup_lib' => $hold['hold']['pickup_lib'],
-                              'holdId' => $hold['id'],
-                              'usr' => $hold['hold']['usr'],
-                              'artPrintTool' => ($hold['material'] == "Art Print" || $hold['material'] == "Tools") ? TRUE : FALSE
-                          ];
-              $i++;
-            }
-          }
-        }
+        break;
       }
     }
+  }
+  // add in a condition if a location is supplied to filter on
+  if (3 == strlen($destLocation)) {
+    $query->condition('branchLocationId', (int) $destLocation, '=');
+  }
+  // add in a condition if a lobbyOnly is supplied to filter on
+  if (NULL != $lobbyOnly) {
+    $query->condition('maxLockers', 0, '=');
+  }
+  // add in a condition for 'Front' versus 'Back' in the location Name
+  if (NULL != $frontBack) {
+    $query->condition('locationName', "%" . $db->escapeLike($frontBack) . "%", 'like');
+  }
+  $result = $query->execute();
+  $pickupLocationRecords = $result->fetchAll();
+
+  return $pickupLocationRecords;
+}
+
+/*
+  * returns an array of active locker pickup locations.
+  */
+function arborcat_locker_pickup_locations() {
+  $locations = [];
+  $db = \Drupal::database();
+  $query = $db->select('arborcat_pickup_location', 'apl')
+      ->fields('apl', ['locationId'])
+      ->condition('maxLockers', 0, '>')
+      ->condition('active', 1, '=')
+      ->execute();
+  $locations = array_values($query->fetchCol());
+
+  return $locations;
+}
+
+  /*
+  * Checks the availability of a locker fo the specified date and timePeriod.
+  * If a branch location is passed in, that a filtered list of pickup locations is returned
+  */
+function arborcat_check_locker_availability($queryDate, $locationObject, $patronId) {
+  $availableLockers = 0;
+  // Query current arborcat_patron_pickup_request records for the date and timePeriod to get inuse count
+  // fields pickupDate & timeSlot
+  $db = \Drupal::database();
+  $pickup_point = $locationObject->locationId;
+
+  $query = $db->select('arborcat_patron_pickup_request', 'appr')
+    ->fields('appr', ['patronId'])
+    ->condition('pickupDate', $queryDate)
+    ->condition('pickupLocation', $pickup_point, '=')
+    ->groupBy('patronId');
+  $results = $query->execute()->fetchCol();
+
+  $lockersInUse = count($results);
+  $availableLockers = $locationObject->maxLockers - $lockersInUse;
+  $returnval = FALSE;
+  // check whether this patron already has a pickup appointment already scheduled for this locker at this time. OR whether there are available lockers at this time
+  if (in_array($patronId, $results) || $availableLockers > 0) {
+    $returnval = TRUE;
+  }
+
+  return ($returnval);
+}
+
+function arborcat_load_patron_eligible_holds($patron_barcode, $requestLocation=NULL) {
+  $guzzle = \Drupal::httpClient();
+  $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+  $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
+  $selfCheckApi_key .= '-' .  $patron_barcode;
+
+  try {
+    $patron_holds = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/holds")->getBody()->getContents(), TRUE);
+
+    // For debugging LWK
+    // $jsonData = file_get_contents('10005279_21621034452183_holds.txt');
+    // $patron_holds = json_decode($jsonData, TRUE);
+  } catch (Exception $e) {
+    $eligible_holds['error'] = 'Info not found';
 
     return $eligible_holds;
   }
+  $eligible_holds = [];
+  //start at 1 to avoid issue with eligible holds array not being zero-based
+  $i=1;
 
-  function arborcat_get_scheduled_pickups($barcode) {
-    $guzzle = \Drupal::httpClient();
-    $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-    $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
-    $selfCheckApi_key .= '-' .  $barcode;
+  $mel_mappings = [
+        113 => 102,
+        114 => 103,
+        115 => 104,
+        116 => 105,
+        117 => 106
+  ];
 
-    $scheduled_pickups = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/scheduled-pickups?range=7")->getBody()->getContents(), TRUE);
-
-    return $scheduled_pickups;
+  $db = \Drupal::database();
+  if (count($patron_holds)) {
+    foreach ($patron_holds as $hold) {
+      if ($hold['status'] == 'Ready for Pickup') {
+        // check if there is a requestLocation to filter on. If not, set $includeLocationBoolean to TRUE, otherwise perform check for location match
+        $includeLocationBoolean = ($requestLocation == NULL) ? TRUE : ($hold['hold']['pickup_lib'] == $requestLocation);
+        if ($includeLocationBoolean || isset($mel_mappings[$hold['hold']['pickup_lib']])) {
+          // if pickup appt already set, don't display item
+          $pickup_req_exists = $db->query("SELECT * from arborcat_patron_pickup_request WHERE requestId = :hid", [':hid' => $hold['id']])->fetch();
+          if (isset($pickup_req_exists->id)) {
+            continue;
+          }
+          $shelf_expire = date('Y-m-d', strtotime($hold['hold']['shelf_expire_time']));
+          if (arborcat_eligible_for_locker($hold) && $shelf_expire >= date('Y-m-d')) {
+            $eligible_holds[$i] = [
+                            'Title' => $hold['title'],
+                            'Status' => $hold['status'],
+                            'PickupLoc' => $hold['pickup'],
+                            'pickup_lib' => $hold['hold']['pickup_lib'],
+                            'holdId' => $hold['id'],
+                            'usr' => $hold['hold']['usr'],
+                            'artPrintTool' => ($hold['material'] == "Art Print" || $hold['material'] == "Tools") ? TRUE : FALSE
+                        ];
+            $i++;
+          }
+        }
+      }
+    }
   }
 
-  function arborcat_create_pickup_request_record($pickup_request_type, $customId, $patronId, $branch, $timeSlot, $pickupLocation, $pickupDate, $contactEmail, $contactSMS, $contactPhone, $lockerCode) {
-    // create arborcat_patron_pickup_request records for each of the selected holds
-    $db = \Drupal::database();
- 
-    // First check if the record already exists for this customId
-    $results = [];
+  return $eligible_holds;
+}
+
+function arborcat_get_scheduled_pickups($barcode) {
+  $guzzle = \Drupal::httpClient();
+  $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+  $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
+  $selfCheckApi_key .= '-' .  $barcode;
+
+  $scheduled_pickups = json_decode($guzzle->get("$api_url/patron/$selfCheckApi_key/scheduled-pickups?range=7")->getBody()->getContents(), TRUE);
+
+  return $scheduled_pickups;
+}
+
+function arborcat_create_pickup_request_record($pickup_request_type, $customId, $patronId, $branch, $timeSlot, $pickupLocation, $pickupDate, $contactEmail, $contactSMS, $contactPhone, $lockerCode) {
+  // create arborcat_patron_pickup_request records for each of the selected holds
+  $db = \Drupal::database();
+
+  // First check if the record already exists for this customId
+  $results = [];
+  try {
+    $query = $db->select('arborcat_patron_pickup_request', 'appr')
+      ->fields('appr', ['id'])
+      ->condition('requestId', $customId, '=');
+    $results = $query->execute()->fetchCol();
+  } catch (Exception $e) {
+    return -1;
+  }
+  // If a record exists containing the $customId, just return the id of the record, otherwise insert a new record with the customId and return the $id of the new record
+  if (count($results) > 0) {
+    return $results[0];
+  } else {
+    $txn = $db->startTransaction();
     try {
-      $query = $db->select('arborcat_patron_pickup_request', 'appr')
-        ->fields('appr', ['id'])
-        ->condition('requestId', $customId, '=');
-      $results = $query->execute()->fetchCol();
+      $dbaction = $db->insert('arborcat_patron_pickup_request')->fields([
+        'requestType'   => $pickup_request_type,
+        'requestId'     => $customId,
+        'patronId'      => $patronId,
+        'branch'        => (int) $branch,
+        'timeSlot'      => $timeSlot,
+        'pickupLocation' => $pickupLocation,
+        'pickupDate'    => $pickupDate,
+        'contactEmail'  => $contactEmail,
+        'contactSMS'    => $contactSMS,
+        'contactPhone'  => $contactPhone,
+        'created'       => time(),
+        'locker_code'   => $lockerCode
+      ]);
+      $id = $dbaction->execute();
+
+      return $id;
     } catch (Exception $e) {
+      $txn->rollBack();
+
       return -1;
     }
-    // If a record exists containing the $customId, just return the id of the record, otherwise insert a new record with the customId and return the $id of the new record
-    if (count($results) > 0) {
-      return $results[0];
-    } else {
-      $txn = $db->startTransaction();
-      try {
-        $dbaction = $db->insert('arborcat_patron_pickup_request')->fields([
-          'requestType'   => $pickup_request_type,
-          'requestId'     => $customId,
-          'patronId'      => $patronId,
-          'branch'        => (int) $branch,
-          'timeSlot'      => $timeSlot,
-          'pickupLocation' => $pickupLocation,
-          'pickupDate'    => $pickupDate,
-          'contactEmail'  => $contactEmail,
-          'contactSMS'    => $contactSMS,
-          'contactPhone'  => $contactPhone,
-          'created'       => time(),
-          'locker_code'   => $lockerCode
-        ]);
-        $id = $dbaction->execute();
-
-        return $id;
-      } catch (Exception $e) {
-        $txn->rollBack();
-
-        return -1;
-      }
-    }
   }
+}
 
-  function barcodeFromPatronId($patronId) {
-    $api_key = \Drupal::config('arborcat.settings')->get('api_key');
-    $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-    $guzzle = \Drupal::httpClient();
-    $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
-    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
-    if ($json) {
-      $barcode =  $json->evg_user->card->barcode;
+function barcodeFromPatronId($patronId) {
+  $api_key = \Drupal::config('arborcat.settings')->get('api_key');
+  $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+  $guzzle = \Drupal::httpClient();
+  $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
+  $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+  if ($json) {
+    $barcode =  $json->evg_user->card->barcode;
 
-      return $barcode;
-    } else {
-      return "";
-    }
+    return $barcode;
+  } else {
+    return "";
   }
+}
 
-  function patronIdFromBarcode($barcode) {
-    $api_key = \Drupal::config('arborcat.settings')->get('api_key');
-    $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-    $guzzle = \Drupal::httpClient();
-    $requestURL = "$api_url/patron?apikey=$api_key&barcode=$barcode";
-    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
-    if ($json) {
-      $patronId =  $json->pid;
+function patronIdFromBarcode($barcode) {
+  $api_key = \Drupal::config('arborcat.settings')->get('api_key');
+  $api_url = \Drupal::config('arborcat.settings')->get('api_url');
+  $guzzle = \Drupal::httpClient();
+  $requestURL = "$api_url/patron?apikey=$api_key&barcode=$barcode";
+  $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+  if ($json) {
+    $patronId =  $json->pid;
 
-      return $patronId;
-    } else {
-      return "";
-    }
+    return $patronId;
+  } else {
+    return "";
   }
+}
   
-  function arborcat_custom_pickup_request($pickup_request_type, $customPickupRequestId) {
-    $resultMessage = '';
-    if ($pickup_request_type == 'PRINT_JOB' || $pickup_request_type == 'GRAB_BAG') {
-      // Extract fields from the printJob request form
-      $db = \Drupal::database();
-      $query = $db->select('webform_submission_data', 'wsd');
-      $query->fields('wsd', ['name', 'value']);
-      $query->condition('sid', $customPickupRequestId, '=');
-      $rawNameValueResults= $query->execute()->fetchAll();
+function arborcat_custom_pickup_request($pickup_request_type, $customPickupRequestId) {
+  $resultMessage = '';
+  if ($pickup_request_type == 'PRINT_JOB' || $pickup_request_type == 'GRAB_BAG') {
+    // Extract fields from the printJob request form
+    $db = \Drupal::database();
+    $query = $db->select('webform_submission_data', 'wsd');
+    $query->fields('wsd', ['name', 'value']);
+    $query->condition('sid', $customPickupRequestId, '=');
+    $rawNameValueResults= $query->execute()->fetchAll();
 
-      // process the raw results and create an associative array of the results.
-      // NOTE notification_options can have multiple entries and this is handled by creating a regular array of the different result values
-      $assocResults = [];
-      foreach ($rawNameValueResults as $entry) {
-        $keyname = $entry->name;
-        if ("notification_options" == $keyname) {
-          if (!array_key_exists($keyname, $assocResults)) {
-            $assocResults[$keyname] = [];
-          }
-          array_push($assocResults[$keyname], $entry->value);
-        } else {
-          $assocResults[$keyname] = $entry->value;
+    // process the raw results and create an associative array of the results.
+    // NOTE notification_options can have multiple entries and this is handled by creating a regular array of the different result values
+    $assocResults = [];
+    foreach ($rawNameValueResults as $entry) {
+      $keyname = $entry->name;
+      if ("notification_options" == $keyname) {
+        if (!array_key_exists($keyname, $assocResults)) {
+          $assocResults[$keyname] = [];
         }
+        array_push($assocResults[$keyname], $entry->value);
+      } else {
+        $assocResults[$keyname] = $entry->value;
       }
-
-      if (count($assocResults) > 0) {
-        $barcode = $assocResults['barcode'];
-        $patronId = (strlen($barcode) == 14) ? patronIdFromBarcode($barcode) : NULL;
-        $branchNameArray = explode(" ", $assocResults['delivery_method']);
-        if ($branchNameArray[0] == 'Mail') {  // Mail to Patron option - no pickup request should be created
-          $resultMessage = 'SUCCESS';
-        }
-        else {
-          $frontBack = ($branchNameArray[1] == 'Back' || $branchNameArray[1] == 'Front') ? $branchNameArray[1] : NULL;
-          $pickupLocations = arborcat_pickup_locations(NULL, $branchNameArray[0], $frontBack, TRUE);
-          $branch = $pickupLocations[0]->branchLocationId;
-          $pickupLocation = $pickupLocations[0]->locationId;
-
-          $timeslot = 0;
-          $pickupDate = $assocResults['pickup_date'];
-          $patronPhone = $assocResults['patron_phone'];
-          $patronEmail = $assocResults['patron_email'];
-          $notification_options = $assocResults['notification_options'];
-          // create new arborcat_pickup_request_record (if one does not already exist)
-          $result = arborcat_create_pickup_request_record(
-            $pickup_request_type,
-            $customPickupRequestId,
-            $patronId,
-            $branch,
-            $timeslot,
-            $pickupLocation,
-            $pickupDate,
-            $patronEmail,
-            (in_array('email', array_map('strtolower', $notification_options))) ? $patronEmail : NULL,
-            (in_array('text', array_map("strtolower", $notification_options))) ? $patronPhone : NULL,
-            (in_array('phone call', array_map("strtolower", $notification_options))) ? $patronPhone : NULL,
-            $patronPhone ?? NULL
-          );
-                                        
-          if ($result > 0) {
-            $resultMessage = 'SUCCESS';
-          } else {
-            $resultMessage = 'Failed to create Pickup Request Record';
-          }
-        }
-      }
-    } elseif ($pickup_request_type == 'SG_ORDER') {
     }
 
-    return $resultMessage;
+    if (count($assocResults) > 0) {
+      $barcode = $assocResults['barcode'];
+      $patronId = (strlen($barcode) == 14) ? patronIdFromBarcode($barcode) : NULL;
+      $branchNameArray = explode(" ", $assocResults['delivery_method']);
+      if ($branchNameArray[0] == 'Mail') {  // Mail to Patron option - no pickup request should be created
+        $resultMessage = 'SUCCESS';
+      }
+      else {
+        $frontBack = ($branchNameArray[1] == 'Back' || $branchNameArray[1] == 'Front') ? $branchNameArray[1] : NULL;
+        $pickupLocations = arborcat_pickup_locations(NULL, $branchNameArray[0], $frontBack, TRUE);
+        $branch = $pickupLocations[0]->branchLocationId;
+        $pickupLocation = $pickupLocations[0]->locationId;
+
+        $timeslot = 0;
+        $pickupDate = $assocResults['pickup_date'];
+        $patronPhone = $assocResults['patron_phone'];
+        $patronEmail = $assocResults['patron_email'];
+        $notification_options = $assocResults['notification_options'];
+        // create new arborcat_pickup_request_record (if one does not already exist)
+        $result = arborcat_create_pickup_request_record(
+          $pickup_request_type,
+          $customPickupRequestId,
+          $patronId,
+          $branch,
+          $timeslot,
+          $pickupLocation,
+          $pickupDate,
+          $patronEmail,
+          (in_array('email', array_map('strtolower', $notification_options))) ? $patronEmail : NULL,
+          (in_array('text', array_map("strtolower", $notification_options))) ? $patronPhone : NULL,
+          (in_array('phone call', array_map("strtolower", $notification_options))) ? $patronPhone : NULL,
+          $patronPhone ?? NULL
+        );
+                                      
+        if ($result > 0) {
+          $resultMessage = 'SUCCESS';
+        } else {
+          $resultMessage = 'Failed to create Pickup Request Record';
+        }
+      }
+    }
+  } elseif ($pickup_request_type == 'SG_ORDER') {
   }
+
+  return $resultMessage;
+}
+
+function arborcat_calculate_pickup_dates() {
+  $arrayOfDates = [];
+  // get the current date
+  $theDate = new DateTime('today');
+  // add 1 day to the current date
+      $startingDayOffset = 1; // Load these from ArborCat Settings?
+      $numPickupDays = 7;     // Load these from ArborCat Settings?
+      $incrementorString = '+$startingDayOffset day';
+  $theDate->modify('+1 day');
+
+  // now loop for x days and create a date string for each day, preceded with the day name
+  // create a human friendly version - 'formattedDate' for display purposes in the UI
+  // and a basic verson 'date' for use in date db queries
+
+  // this is not ideal whatsoever and just quick way to address unavailable / closure dates
+  $date_exclude = [
+          'Jun. 20',
+          'Jun. 21',
+          'Jul. 4',
+          'Sep. 7'
+      ];
+  for ($x=0; $x < $numPickupDays; $x++) {
+    $theDate_mdY = $theDate->format('M. j');
+    $day_of_week = intval($theDate->format('w'));
+    $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
+    $datestring = $dayOfWeek . ', ' . $theDate_mdY;
+
+    $datestr_Ymd = $theDate->format('Y-m-d');
+    $twoDates = array("date" => $datestr_Ymd, "formattedDate" => $datestring);
+
+    if (!in_array($theDate_mdY, $date_exclude)) {
+      $arrayOfDates[$datestr_Ymd] = $twoDates;
+    }
+    $theDate->modify('+1 day');
+  }
+
+  return $arrayOfDates;
+}
+
+function dblog(...$thingsToLog)
+{
+  $lineToLog = '';
+  foreach ($thingsToLog as $item) {
+    //$lineToLog = $lineToLog . ' ' . print_r($item, true);
+    $item2 = $item;
+    if (is_array($item)) {
+      $item2 = ' ARRAY: ' . json_encode($item);
+    }
+    else if (is_object($item)) {
+      $item2 = 'OBJECT: ' . json_encode($item);
+    }
+    $lineToLog .= ' ' . $item2;
+  }
+  // prepend date/time onto log line
+  $nowDateTime = new DrupalDateTime();
+  $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
+  $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
+  error_log($completeLine, 3, "LWKLWK.log");
+}

--- a/arborcat.module
+++ b/arborcat.module
@@ -455,17 +455,28 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
 
 function arborcat_calculate_pickup_dates() {
   $arrayOfDates = [];
-  // get the current date
-  $theDate = new DateTime('today');
-  // add 1 day to the current date
-      $startingDayOffset = 1; // Load these from ArborCat Settings?
-      $numPickupDays = 7;     // Load these from ArborCat Settings?
-      $incrementorString = '+$startingDayOffset day';
-  $theDate->modify('+1 day');
+ 
+  $startingDayOffset = 1; // Load these from ArborCat Settings?
+  $numPickupDays = 90;     // Load these from ArborCat Settings?
+  $startingDay = new DateTime('+' . $startingDayOffset . ' day');
+  $startingDayPlusPickup = new DateTime('+' . $numPickupDays . ' days');
+  dblog('arborcat_calculate_pickup_dates:                startDate =', $startingDay->format('Y-m-d'));
+  dblog('arborcat_calculate_pickup_dates: startingDayPlusPickup =', $startingDayPlusPickup->format('Y-m-d'));
 
   // now loop for x days and create a date string for each day, preceded with the day name
   // create a human friendly version - 'formattedDate' for display purposes in the UI
   // and a basic verson 'date' for use in date db queries
+
+  // Load exclusion dates for the next $numPickup Days from the table: arborcat_pickup_location_exclusion
+  $db = \Drupal::database();
+  $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
+  $query->fields('aple', ['locationId', 'dateStart', 'dateEnd']);
+  $query->condition('dateStart', $startingDay->format('Y-m-d'), '>=');
+  $query->condition('dateStart', $startingDayPlusPickup->format('Y-m-d'), '<=');
+  $query->condition('locationId', 9999, '=');
+  $result = $query->execute();
+  $exclusionData = $result->fetchAll();
+  dblog('exclusionData: ', json_encode($exclusionData));
 
   // this is not ideal whatsoever and just quick way to address unavailable / closure dates
   $date_exclude = [
@@ -475,18 +486,18 @@ function arborcat_calculate_pickup_dates() {
           'Sep. 7'
       ];
   for ($x=0; $x < $numPickupDays; $x++) {
-    $theDate_mdY = $theDate->format('M. j');
-    $day_of_week = intval($theDate->format('w'));
+    $theDate_mdY = $startingDay->format('M. j');
+    $day_of_week = intval($startingDay->format('w'));
     $dayOfWeek = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
     $datestring = $dayOfWeek . ', ' . $theDate_mdY;
 
-    $datestr_Ymd = $theDate->format('Y-m-d');
+    $datestr_Ymd = $startingDay->format('Y-m-d');
     $twoDates = array("date" => $datestr_Ymd, "formattedDate" => $datestring);
 
     if (!in_array($theDate_mdY, $date_exclude)) {
       $arrayOfDates[$datestr_Ymd] = $twoDates;
     }
-    $theDate->modify('+1 day');
+    $startingDay->modify('+1 day');
   }
 
   return $arrayOfDates;

--- a/arborcat.module
+++ b/arborcat.module
@@ -476,9 +476,9 @@ function arborcat_get_pickup_dates($location, $start_date_ymd, $end_date_ymd) {
   // For all branches (locationId=9999)
   $pickup_dates = [];
   // Loop through each date, 1 day at a time, checking if there is an exclusion.
-  $starting_date = new DateTime($start_date_ymd);
+  $date_iterator = new DateTime($start_date_ymd);
   $ending_date = new DateTime($end_date_ymd);
-  while ($starting_date <= $ending_date) {
+  while ($date_iterator <= $ending_date) {
     $db = \Drupal::database();
     $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
     $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
@@ -494,8 +494,8 @@ function arborcat_get_pickup_dates($location, $start_date_ymd, $end_date_ymd) {
     // always push the location passed in because the exclusion record may contain
     array_push($query_location_ids, $location);
     $query->condition('locationId', $query_location_ids, 'IN');
-    $query->condition('dateStart', date_format($starting_date, 'Y-m-d'), '<=');
-    $query->condition('dateEnd', date_format($starting_date, 'Y-m-d'), '>=');
+    $query->condition('dateStart', date_format($date_iterator, 'Y-m-d'), '<=');
+    $query->condition('dateEnd', date_format($date_iterator, 'Y-m-d'), '>=');
     // sort the exclusions that match the date by location in descending order so library-wide (9999) closures are first in the array of found exclusions
     $query->orderBy('locationId', 'DESC');
 
@@ -507,14 +507,14 @@ function arborcat_get_pickup_dates($location, $start_date_ymd, $end_date_ymd) {
       $exclusion_data = $exclusion_data_array[0];
     }
     // format the display string for the date that will be shown in the pickup dates dropdown menu
-    $date_month_day = $starting_date->format('M. j');
-    $day_of_week = intval($starting_date->format('w'));
+    $date_month_day = $date_iterator->format('M. j');
+    $day_of_week = intval($date_iterator->format('w'));
     $day_of_week_string = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat',][$day_of_week];
     $day_month_daynum = $day_of_week_string . ', ' . $date_month_day;
-    $datestr_Ymd = $starting_date->format('Y-m-d');
+    $datestr_Ymd = $date_iterator->format('Y-m-d');
     $pickup_dates[$datestr_Ymd] = ['display_date_string' => $day_month_daynum, 'date_exclusion_data' => $exclusion_data];
 
-    $starting_date->modify('+1 day');
+    $date_iterator->modify('+1 day');
   }
 
   return $pickup_dates;

--- a/arborcat.module
+++ b/arborcat.module
@@ -453,8 +453,30 @@ function arborcat_custom_pickup_request($pickup_request_type, $customPickupReque
   return $resultMessage;
 }
 
-function processExclusionData($exclusionData) {
+ function arborcat_load_exclusion_data($loadScope, $startDateYmd, $endDateYmd) {
+   dblog('ENTERED arborcat_load_exclusion_data', $loadScope, '|', $startDateYmd, '|',  $endDateYmd);
+// Load exclusion dates for all branches (locationId=9999) for the next $numPickup Days from the table: arborcat_pickup_location_exclusion
+  $db = \Drupal::database();
+  $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
+  $query->fields('aple', ['locationId', 'dateStart', 'dateEnd','display_reason']);
+  $query->condition('dateStart', $startDateYmd, '>=');
+  $query->condition('dateStart', $endDateYmd, '<=');
+  if ('DISTRICT_WIDE' == $loadScope) {
+    $query->condition('locationId', 9999, '=');
+  }
+  else {
+    $query->condition('locationId', 9999, '<>');
+  }
+  $result = $query->execute();
+  $exclusionData = $result->fetchAll();
+  dblog('arborcat_load_exclusion_data: RETURNING exclusionData = ', $exclusionData);
+
+  return $exclusionData;
+}
+
+function arborcat_process_exclusion_data($exclusionData) {
   $exclusionDates = [];
+  
   foreach ($exclusionData as $exclusionDataRec) {
     $start = $exclusionDataRec->dateStart;
     $end = $exclusionDataRec->dateEnd;
@@ -475,29 +497,24 @@ function processExclusionData($exclusionData) {
   return $exclusionDates;
 }
 
-function arborcat_calculate_pickup_dates() { 
+function arborcat_calculate_pickup_dates($exclusionData) { 
+  dblog('arborcat_calculate_pickup_dates: ENTERED $exclusionData =', $exclusionData);
   $startingDayOffset = 1; // Load these from ArborCat Settings?
   $numPickupDays = 7;     // Load these from ArborCat Settings?
   $startingDay = new DateTime('+' . $startingDayOffset . ' day');
   $startingDayPlusPickupDays = clone $startingDay;
   $startingDayPlusPickupDays->modify('+' . $numPickupDays . ' days');
 
+  if (NULL == $exclusionData) {
+    dblog('arborcat_calculate_pickup_dates: $exclusionData == NULL');
+    $exclusionData = arborcat_load_exclusion_data('DISTRICT_WIDE', $startingDay->format('Y-m-d'), $startingDayPlusPickupDays->format('Y-m-d'));
+  }
+  dblog('arborcat_calculate_pickup_dates: AFTER NULL CHECK $exclusionData =', $exclusionData);
+  $exclusionDates = arborcat_process_exclusion_data($exclusionData);
+
   // now loop for x days and create a date string for each day, preceded with the day name
   // create a human friendly version - 'formattedDate' for display purposes in the UI
   // and a basic verson 'date' for use in date db queries
-
-  // Load exclusion dates for all branches (locationId=9999) for the next $numPickup Days from the table: arborcat_pickup_location_exclusion
-  $db = \Drupal::database();
-  $query = $db->select('arborcat_pickup_location_exclusion', 'aple');
-  $query->fields('aple', ['locationId', 'dateStart', 'dateEnd']);
-  $query->condition('dateStart', $startingDay->format('Y-m-d'), '>=');
-  $query->condition('dateStart', $startingDayPlusPickupDays->format('Y-m-d'), '<=');
-  $query->condition('locationId', 9999, '=');
-  $result = $query->execute();
-  $exclusionData = $result->fetchAll();
-
-  $exclusionDates = processExclusionData($exclusionData);
-
   $interval = \DateInterval::createFromDateString('1 day');
   $period = new \DatePeriod($startingDay, $interval, $startingDayPlusPickupDays);
 
@@ -513,4 +530,23 @@ function arborcat_calculate_pickup_dates() {
     }
   }
   return $pickupdates;
+}
+
+function dblog(...$thingsToLog) {
+  $lineToLog = '';
+  foreach ($thingsToLog as $item) {
+    //$lineToLog = $lineToLog . ' ' . print_r($item, true);
+    $item2 = $item;
+    if (is_array($item)) {
+      $item2 = ' ARRAY: ' . json_encode($item);
+    } elseif (is_object($item)) {
+      $item2 = 'OBJECT: ' . json_encode($item);
+    }
+    $lineToLog .= ' ' . $item2;
+  }
+  // prepend date/time onto log line
+  $nowDateTime = new DrupalDateTime();
+  $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
+  $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
+  error_log($completeLine, 3, "LWKLWK.log");
 }

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -3,12 +3,23 @@
     attach: function (context, settings) {
       $(document, context).once('pickupRequestBehavior').each(function () {
         var max_locker_items_check = drupalSettings.arborcat.max_locker_items_check;
+        var exclusion_marker_string = drupalSettings.arborcat.exclusion_marker_string;
 
         $(function () {
           // INITIALIZATION/SETUP
+          var pickup_date_select_field = $("#edit-pickup-date");
+          // check each of the option display strngs for each date to see whether the exclusion_marker_string has been appended to the end of the date.
+          // If so, disable the menu item
+          var options = $('#edit-pickup-date option');
+          for (var index=0; index < options.length; index++) {
+            var an_option = options[index];
+            var option_outer_text = an_option.outerText;
+            if (option_outer_text.includes(exclusion_marker_string)) {
+              $(an_option).attr('disabled','disabled');
+            }
+          }
 
-          // helper methods
-          function checkedItems() {
+         function checkedItems() {
             var numitems = $("#edit-item-table tbody tr").length;
             var numchecked = 0;
             for (var i = numitems; i > 0; i--) {

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -426,12 +426,10 @@ class DefaultController extends ControllerBase {
     //     $pickupdates[$data_item_key] = $data_item_value['display_date_string'] . $append_string;
     //   }
     //   dblog('AFTER FOREACH - pickupdates = ', $pickupdates);
-
-
-    return [
-      '#title' => 'pickup request test',
-      '#markup' => json_encode($stuff)
-    ];
+    // return [
+    //   '#title' => 'pickup request test',
+    //   '#markup' => json_encode($stuff)
+    // ];
 
     $barcode = \Drupal::request()->query->get('barcode');
     $patron_id = \Drupal::request()->query->get('patronid');

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -408,15 +408,15 @@ class DefaultController extends ControllerBase {
   }
 
   public function pickup_test() {
-    dblog('pickup_test ENTERED');
     $returnval = '';
     
-    $pickupDates = arborcat_calculate_pickup_dates();
-    dblog('pickupDates', json_encode($pickupDates));
-    return [
-      '#title' => 'pickup request test',
-      '#markup' => $returnval
-    ];
+    // For testing pickupDate calculate method changes
+    // $pickupDates = arborcat_calculate_pickup_dates();
+    // dblog('pickupDates', json_encode($pickupDates));
+    // return [
+    //   '#title' => 'pickup request test',
+    //   '#markup' => $returnval
+    // ];
 
     $barcode = \Drupal::request()->query->get('barcode');
     $patronId = \Drupal::request()->query->get('patronid');

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -408,14 +408,15 @@ class DefaultController extends ControllerBase {
   }
 
   public function pickup_test() {
+    //dblog('pickup_test ENTERED');
     $returnval = '';
     
-    // For testing pickupDate calculate method changes
+    // // For testing pickupDate calculate method changes
     // $pickupDates = arborcat_calculate_pickup_dates();
     // dblog('pickupDates', json_encode($pickupDates));
     // return [
     //   '#title' => 'pickup request test',
-    //   '#markup' => $returnval
+    //   '#markup' => json_encode($pickupDates)
     // ];
 
     $barcode = \Drupal::request()->query->get('barcode');

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -478,11 +478,11 @@ class DefaultController extends ControllerBase {
     ];
   }
 
-  public function pickup_request($patron_id, $encrypted_barcode, $loc) {
+  public function pickup_request($pnum, $encrypted_barcode, $loc) {
       $mode = \Drupal::request()->query->get('mode');
       $request_pickup_html = '';
-      if ($this->validateTransaction($patron_id, $encrypted_barcode)) {
-          $request_pickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $patron_id, $loc, $mode);
+      if ($this->validateTransaction($pnum, $encrypted_barcode)) {
+          $request_pickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $pnum, $loc, $mode);
       } else {
           drupal_set_message('The Pickup Request could not be processed');
       }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -455,15 +455,17 @@ class DefaultController extends ControllerBase {
   public function pickup_request($pnum, $encrypted_barcode, $loc) {
       $mode = \Drupal::request()->query->get('mode');
       $request_pickup_html = '';
+      $exclusion_marker_string = \Drupal::config('arborcat.settings')->get('exclusion_marker_string');
       if ($this->validateTransaction($pnum, $encrypted_barcode)) {
-          $request_pickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $pnum, $loc, $mode);
+          $request_pickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $pnum, $loc, $mode, $exclusion_marker_string);
       } else {
           drupal_set_message('The Pickup Request could not be processed');
       }
       $render[] = [
               '#theme' => 'pickup_request_form',
               '#formhtml' => $request_pickup_html,
-              '#max_locker_items_check' => \Drupal::config('arborcat.settings')->get('max_locker_items_check')
+              '#max_locker_items_check' => \Drupal::config('arborcat.settings')->get('max_locker_items_check'),
+              '#exclusion_marker_string' => $exclusion_marker_string,
           ];
       return $render;
   } 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -407,17 +407,36 @@ class DefaultController extends ControllerBase {
       return $link;
   }
 
+  // ----------------------------------
+  // ----------------------------------
   public function pickup_test() {
-    //dblog('pickup_test ENTERED');
     $returnval = '';
     
-    // // For testing pickupDate calculate method changes
-    // $pickupDates = arborcat_calculate_pickup_dates();
-    // dblog('pickupDates', json_encode($pickupDates));
-    // return [
-    //   '#title' => 'pickup request test',
-    //   '#markup' => json_encode($pickupDates)
-    // ];
+    $date1 = new DateTime("2020-11-01 23:59:59", new DateTimeZone('UTC'));
+    $date2 = clone $date1;
+    $date2->modify('+45 days');
+    // for ($i=1; $i<14; $i++) {
+    //   dblog("LOOP: ** $i **");
+    //   $stuff = arborcat_get_pickup_dates(102, date_format($date1, 'Y-m-d'), date_format($date2, 'Y-m-d'));
+    //   $date1->modify('+1 day');
+    //   $date2->modify('+1 day');
+    // }
+    // For testing pickupDate calculate method changes
+    // $stuff = arborcat_get_pickup_dates(102, date_format($date1, 'Y-m-d'), date_format($date2, 'Y-m-d'));
+
+    //   $pickupdates =[];
+    //   foreach ($stuff as $data_item_key => $data_item_value) {
+    //     dblog('FOREACH ', $data_item_key, $data_item_value);
+    //     $append_string =  ($data_item_value['date_exclusion_data'] != null) ? ' * not available *' : '';
+    //     $pickupdates[$data_item_key] = $data_item_value['display_date_string'] . $append_string;
+    //   }
+    //   dblog('AFTER FOREACH - pickupdates = ', $pickupdates);
+
+
+    return [
+      '#title' => 'pickup request test',
+      '#markup' => json_encode($stuff)
+    ];
 
     $barcode = \Drupal::request()->query->get('barcode');
     $patronId = \Drupal::request()->query->get('patronid');
@@ -446,9 +465,9 @@ class DefaultController extends ControllerBase {
         }
         else {
             if (strlen($patronId) > 0) {
-                $barcode =  barcodeFromPatronId($patronId);
+                $barcode =  barcode_from_patron_id($patronId);
             } else {
-                $patronId = patronIdFromBarcode($barcode);
+                $patronId = patron_id_from_barcode($barcode);
             }
             if (14 === strlen($barcode)) {
               if (strlen($row) > 0) {
@@ -493,7 +512,7 @@ class DefaultController extends ControllerBase {
   }
 
   public function cancel_pickup_request($patron_barcode, $encrypted_request_id, $hold_shelf_expire_date) {
-      $patron_id = patronIdFromBarcode($patron_barcode);
+      $patron_id = patron_id_from_barcode($patron_barcode);
       $cancelRecord = $this->findRecordToCancel($patron_id, $encrypted_request_id);
       if (count($cancelRecord) > 0) {
           $db = \Drupal::database();
@@ -541,7 +560,7 @@ class DefaultController extends ControllerBase {
 
   private function validateTransaction($pnum, $encrypted_barcode) {
     $returnval = FALSE;
-    $barcode =  barcodeFromPatronId($pnum);
+    $barcode =  barcode_from_patron_id($pnum);
     if (14 == strlen($barcode)) {
         $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
         $hashedBarcode = md5($pickup_requests_salt . $barcode);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -465,9 +465,9 @@ class DefaultController extends ControllerBase {
         }
         else {
             if (strlen($patronId) > 0) {
-                $barcode =  barcode_from_patron_id($patronId);
+                $barcode =  arborcat_barcode_from_patron_id($patronId);
             } else {
-                $patronId = patron_id_from_barcode($barcode);
+                $patronId = arborcat_patron_id_from_barcode($barcode);
             }
             if (14 === strlen($barcode)) {
               if (strlen($row) > 0) {
@@ -512,7 +512,7 @@ class DefaultController extends ControllerBase {
   }
 
   public function cancel_pickup_request($patron_barcode, $encrypted_request_id, $hold_shelf_expire_date) {
-      $patron_id = patron_id_from_barcode($patron_barcode);
+      $patron_id = arborcat_patron_id_from_barcode($patron_barcode);
       $cancelRecord = $this->findRecordToCancel($patron_id, $encrypted_request_id);
       if (count($cancelRecord) > 0) {
           $db = \Drupal::database();
@@ -560,7 +560,7 @@ class DefaultController extends ControllerBase {
 
   private function validateTransaction($pnum, $encrypted_barcode) {
     $returnval = FALSE;
-    $barcode =  barcode_from_patron_id($pnum);
+    $barcode =  arborcat_barcode_from_patron_id($pnum);
     if (14 == strlen($barcode)) {
         $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
         $hashedBarcode = md5($pickup_requests_salt . $barcode);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -406,30 +406,6 @@ class DefaultController extends ControllerBase {
   // ----------------------------------
   public function pickup_test() {
     $return_val = '';
-    
-    // $date1 = new DateTime("2020-11-01 23:59:59", new DateTimeZone('UTC'));
-    // $date2 = clone $date1;
-    // $date2->modify('+45 days');
-    // for ($i=1; $i<14; $i++) {
-    //   dblog("LOOP: ** $i **");
-    //   $stuff = arborcat_get_pickup_dates(102, date_format($date1, 'Y-m-d'), date_format($date2, 'Y-m-d'));
-    //   $date1->modify('+1 day');
-    //   $date2->modify('+1 day');
-    // }
-    // For testing pickupDate calculate method changes
-    // $stuff = arborcat_get_pickup_dates(102, date_format($date1, 'Y-m-d'), date_format($date2, 'Y-m-d'));
-
-    //   $pickupdates =[];
-    //   foreach ($stuff as $data_item_key => $data_item_value) {
-    //     dblog('FOREACH ', $data_item_key, $data_item_value);
-    //     $append_string =  ($data_item_value['date_exclusion_data'] != null) ? ' * not available *' : '';
-    //     $pickupdates[$data_item_key] = $data_item_value['display_date_string'] . $append_string;
-    //   }
-    //   dblog('AFTER FOREACH - pickupdates = ', $pickupdates);
-    // return [
-    //   '#title' => 'pickup request test',
-    //   '#markup' => json_encode($stuff)
-    // ];
 
     $barcode = \Drupal::request()->query->get('barcode');
     $patron_id = \Drupal::request()->query->get('patronid');

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -407,9 +407,9 @@ class DefaultController extends ControllerBase {
   public function pickup_test() {
     $return_val = '';
     
-    $date1 = new DateTime("2020-11-01 23:59:59", new DateTimeZone('UTC'));
-    $date2 = clone $date1;
-    $date2->modify('+45 days');
+    // $date1 = new DateTime("2020-11-01 23:59:59", new DateTimeZone('UTC'));
+    // $date2 = clone $date1;
+    // $date2->modify('+45 days');
     // for ($i=1; $i<14; $i++) {
     //   dblog("LOOP: ** $i **");
     //   $stuff = arborcat_get_pickup_dates(102, date_format($date1, 'Y-m-d'), date_format($date2, 'Y-m-d'));

--- a/src/Form/ArborcatAdminForm.php
+++ b/src/Form/ArborcatAdminForm.php
@@ -11,48 +11,44 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 
-class ArborcatAdminForm extends ConfigFormBase
-{
+class ArborcatAdminForm extends ConfigFormBase {
 
   /**
    * {@inheritdoc}
    */
-    public function getFormId()
-    {
-        return 'arborcat_admin_form';
+  public function getFormId() {
+    return 'arborcat_admin_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('arborcat.settings');
+
+    foreach (Element::children($form) as $variable) {
+      $config->set($variable, $form_state->getValue($form[$variable]['#parents']));
+    }
+    $config->save();
+
+    if (method_exists($this, '_submitForm')) {
+      $this->_submitForm($form, $form_state);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state)
-    {
-        $config = $this->config('arborcat.settings');
+    parent::submitForm($form, $form_state);
+  }
 
-        foreach (Element::children($form) as $variable) {
-            $config->set($variable, $form_state->getValue($form[$variable]['#parents']));
-        }
-        $config->save();
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['arborcat.settings'];
+  }
 
-        if (method_exists($this, '_submitForm')) {
-            $this->_submitForm($form, $form_state);
-        }
+  public function buildForm(array $form, \Drupal\Core\Form\FormStateInterface $form_state) {
+    $form = [];
 
-        parent::submitForm($form, $form_state);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getEditableConfigNames()
-    {
-        return ['arborcat.settings'];
-    }
-
-    public function buildForm(array $form, \Drupal\Core\Form\FormStateInterface $form_state)
-    {
-        $form = [];
-        $form['api_url'] = [
+    $form['api_url'] = [
       '#type' => 'textfield',
       '#title' => t('API URL'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('api_url'),
@@ -60,7 +56,8 @@ class ArborcatAdminForm extends ConfigFormBase
       '#maxlength' => 64,
       '#description' => t('URL of the API server for Arborcat. (e.g. https://api.website.org)'),
     ];
-        $form['api_key'] = [
+
+    $form['api_key'] = [
       '#type' => 'textfield',
       '#title' => t('API Auth Key'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('api_key'),
@@ -68,7 +65,7 @@ class ArborcatAdminForm extends ConfigFormBase
       '#maxlength' => 64,
       '#description' => t('API Key for authentication'),
     ];
-        $form['mcb_lockers'] = [
+    $form['mcb_lockers'] = [
       '#type' => 'textfield',
       '#title' => t('MCB Lockers URL'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('mcb_lockers'),
@@ -76,7 +73,8 @@ class ArborcatAdminForm extends ConfigFormBase
       '#maxlength' => 64,
       '#description' => t('Lockers URL for checking availability'),
     ];
-        $form['pts_lockers'] = [
+
+    $form['pts_lockers'] = [
       '#type' => 'textfield',
       '#title' => t('PTS Lockers URL'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('pts_lockers'),
@@ -84,7 +82,8 @@ class ArborcatAdminForm extends ConfigFormBase
       '#maxlength' => 64,
       '#description' => t('Lockers URL for checking availability'),
     ];
-        $form['pts_lockers_insert'] = [
+
+    $form['pts_lockers_insert'] = [
       '#type' => 'textfield',
       '#title' => t('PTS Lockers Insert URL'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('pts_lockers_insert'),
@@ -92,7 +91,8 @@ class ArborcatAdminForm extends ConfigFormBase
       '#maxlength' => 64,
       '#description' => t('Lockers URL for adding lockers'),
     ];
-        $form['lockers_pass'] = [
+
+    $form['lockers_pass'] = [
       '#type' => 'textfield',
       '#title' => t('Lockers Interface Password'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('lockers_pass'),
@@ -101,7 +101,7 @@ class ArborcatAdminForm extends ConfigFormBase
       '#description' => t('Password for accessing lockers interfaces'),
     ];
 
-        $form['pickup_requests_salt'] = [
+    $form['pickup_requests_salt'] = [
       '#type' => 'textfield',
       '#title' => t('Salt for pickup requests'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('pickup_requests_salt'),
@@ -110,7 +110,7 @@ class ArborcatAdminForm extends ConfigFormBase
       '#description' => t('Salt string for unpacking barcode numbers for pickup requests'),
     ];
 
-        $form['selfcheck_key'] = [
+    $form['selfcheck_key'] = [
       '#type' => 'textfield',
       '#title' => t('Self-check key for patron api requests'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('selfcheck_key'),
@@ -119,12 +119,34 @@ class ArborcatAdminForm extends ConfigFormBase
       '#description' => t('self-check key for use with api requests pertaining to the patron data without the need to be signed in'),
     ];
  
-         $form['max_locker_items_check'] = [
+    $form['max_locker_items_check'] = [
       '#type' => 'number',
       '#title' => t('Max Number of Items that should fit in a Locker'),
       '#default_value' => \Drupal::config('arborcat.settings')->get('max_locker_items_check'),
       '#description' => t('If more items that this number are selected for locker pickup, a warning will be displayed to the patron'),
     ];
+
+    $form['starting_day_offset'] = [
+      '#type' => 'number',
+      '#title' => t('Starting Day Offset'),
+      '#default_value' => \Drupal::config('arborcat.settings')->get('starting_day_offset'),
+      '#description' => t('Number of days from today until the starting day of pickup dates that will be displayed to the user'),
+    ];
+
+    $form['number_of_pickup_days'] = [
+      '#type' => 'number',
+      '#title' => t('Number of Pickup Days'),
+      '#default_value' => \Drupal::config('arborcat.settings')->get('number_of_pickup_days'),
+      '#description' => t('Number of pickup dates that will be displayed to the user'),
+    ];
+
+    $form['exclusion_marker_string'] = [
+      '#type' => 'textfield',
+      '#title' => t('Date Unavailable marker'),
+      '#default_value' => \Drupal::config('arborcat.settings')->get('exclusion_marker_string'),
+      '#description' => t('Marker string indicating that a pickup date in unavailable. This string is appended to pickup date options in the form select field'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 }

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -120,16 +120,10 @@ class UserPickupRequestForm extends FormBase {
             '#suffix' => '</div>',
             '#default_value' => $selection
         ];
-
-    $possibleDates = arborcat_calculate_pickup_dates();
-    
-    $pickupdates = [];
-    foreach ($possibleDates as $key => $dateStringsArray) {
-      $pickupdates[$key] = $dateStringsArray['formattedDate'];
-    }
-
+ 
     if (!isset($cancel_holds)) {
       // Populate the possible pickup dates popup menu
+      $pickupdates = arborcat_calculate_pickup_dates();
       $form['pickup_date'] = [
               '#prefix' => '<div class="l-inline-b side-by-side-form">',
               '#type' => 'select',

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -121,7 +121,8 @@ class UserPickupRequestForm extends FormBase {
             '#default_value' => $selection
         ];
 
-    $possibleDates = $this->calculateLobbyPickupDates();
+    $possibleDates = $this->arborcat_calculate_pickup_dates();
+    
     $pickupdates = [];
     foreach ($possibleDates as $key => $dateStringsArray) {
       $pickupdates[$key] = $dateStringsArray['formattedDate'];

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -121,7 +121,7 @@ class UserPickupRequestForm extends FormBase {
             '#default_value' => $selection
         ];
 
-    $possibleDates = $this->arborcat_calculate_pickup_dates();
+    $possibleDates = arborcat_calculate_pickup_dates();
     
     $pickupdates = [];
     foreach ($possibleDates as $key => $dateStringsArray) {

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -245,10 +245,12 @@ class UserPickupRequestForm extends FormBase {
       // Check for exclusion dates 
       $exclusion_data = $form_state->get('exclusionData');
       $exclusion_data_object = $exclusion_data[$pickup_date]['date_exclusion_data'];
-      $exclusion_data_array = (array)$exclusion_data_object;
-      $exclusion_error_message = $exclusion_data_array['display_reason'];
-      if (strlen($exclusion_error_message) > 0) {
-        $form_state->setErrorByName('pickup_date', t($exclusion_error_message));
+      if ($exclusion_data_object) {
+        $exclusion_data_array = (array)$exclusion_data_object;
+        $exclusion_error_message = $exclusion_data_array['display_reason'];
+        if (strlen($exclusion_error_message) > 0) {
+          $form_state->setErrorByName('pickup_date', t($exclusion_error_message));
+        }
       }
 
       // check to see if locker pickup

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -16,7 +16,7 @@ class UserPickupRequestForm extends FormBase {
     return 'user_pickup_request_form';
   }
 
-  public function buildForm(array $form, FormStateInterface $form_state, string $patron_id = NULL, string $request_location = NULL, string $mode = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, string $patron_id = NULL, string $request_location = NULL, string $mode = NULL, string $exclusion_marker_string = NULL) {
     $guzzle = \Drupal::httpClient();
     $api_key = \Drupal::config('arborcat.settings')->get('api_key');
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
@@ -123,8 +123,8 @@ class UserPickupRequestForm extends FormBase {
         ];
  
     if (!isset($cancel_holds)) {
-      $starting_day_offset = 1; // Load these from ArborCat Settings?
-      $number_of_pickup_days = 7;     // Load these from ArborCat Settings?
+      $starting_day_offset = \Drupal::config('arborcat.settings')->get('starting_day_offset');
+      $number_of_pickup_days = \Drupal::config('arborcat.settings')->get('number_of_pickup_days');
       $starting_day = new DateTime('+' . $starting_day_offset . ' day');
       
       // SPECIAL CASE for library-wide closure in order to force starting date to be the first day after the closure if 
@@ -143,7 +143,7 @@ class UserPickupRequestForm extends FormBase {
       
       $pickup_dates =[];
       foreach ($pickup_dates_data as $data_item_key => $data_item_value) {
-        $append_string =  ($data_item_value['date_exclusion_data'] != NULL) ? ' * not available *' : '';
+        $append_string =  ($data_item_value['date_exclusion_data'] != NULL) ? ' ' . $exclusion_marker_string : '';
         $pickup_dates[$data_item_key] = $data_item_value['display_date_string'] . $append_string;
       }
       $form['pickup_date'] = [


### PR DESCRIPTION
Created an arborcat method: arborcat_calculate_pickup_dates
Created new drupal database table: arborcat_pickup_location_exclusion
The arborcat_calculate_pickup_dates method loads the exclusion dates for all library branches from a new database table 'arborcat_pickup_location_exclusion' and is used  by the UserPickupRequest form to seed the pickup date select field
This should be the used by all pickup request forms - it should be simple to use in the uc_summergame prize pickup request form and in the printing and shelfservice web forms to seed the pickup date fields.
Additional work will be needed to support individual location exclusions and will be needed for the november elections at PTS and DTN.