### PR TITLE
Pickup requests cancel

### DIFF
--- a/arborcat.module
+++ b/arborcat.module
@@ -375,7 +375,7 @@ function arborcat_barcode_from_patron_id($patron_id) {
     $return_val = $barcode;
   }
   
-  return return_val;
+  return $return_val;
 }
 
 function arborcat_patron_id_from_barcode($barcode) {

--- a/arborcat.module
+++ b/arborcat.module
@@ -347,7 +347,7 @@ function arborcat_create_pickup_request_record($pickup_request_type, $custom_id,
 
       return $id;
     } catch (Exception $e) {
-      drupal_set_message('An error occurred saving this pickup request. Please try again');
+      drupal_set_message('An error occurred saving this pickup request. Please try again', 'error');
       $txn->rollBack();
 
       return -1;
@@ -402,7 +402,7 @@ function arborcat_patron_id_from_barcode($barcode) {
 }
 
 function arborcat_custom_pickup_request($pickup_request_type, $custom_pickup_request_id) {
-  $resultMessage = '';
+  $result_message = '';
   if ($pickup_request_type == 'PRINT_JOB' || $pickup_request_type == 'GRAB_BAG') {
     // Extract fields from the printJob request form
     $db = \Drupal::database();

--- a/arborcat.module
+++ b/arborcat.module
@@ -464,18 +464,3 @@ function arborcat_patron_fines_expired($fines, $patron) {
 
     return $resultMessage;
   }
-
-  /*
-* Debugging routine to log to the <root folder>/LWKLWK.log IN arborcat.module
-*/
-function dblog(...$thingsToLog) {
-  $lineToLog = '';
-  foreach ($thingsToLog as $item) {
-    $lineToLog = $lineToLog . ' ' . print_r($item, TRUE);
-  }
-  // prepend date/time onto log line
-  $nowDateTime = new DrupalDateTime();
-  $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
-  $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
-  error_log($completeLine, 3, "LWKLWK.log");
-}

--- a/arborcat.module
+++ b/arborcat.module
@@ -209,7 +209,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
    * Checks the availability of a locker fo the specified date and timePeriod.
    * If a branch location is passed in, that a filtered list of pickup locations is returned
    */
-  function arborcat_check_locker_availability($queryDate, $locationObject, $patronId) {
+  function arborcat_check_locker_availability($queryDate, $locationObject, $patron_id) {
     $availableLockers = 0;
     // Query current arborcat_patron_pickup_request records for the date and timePeriod to get inuse count
     // fields pickupDate & timeSlot
@@ -227,7 +227,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
     $availableLockers = $locationObject->maxLockers - $lockersInUse;
     $returnval = FALSE;
     // check whether this patron already has a pickup appointment already scheduled for this locker at this time. OR whether there are available lockers at this time
-    if (in_array($patronId, $results) || $availableLockers > 0) {
+    if (in_array($patron_id, $results) || $availableLockers > 0) {
       $returnval = TRUE;
     }
 
@@ -307,7 +307,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
     return $scheduled_pickups;
   }
 
-  function arborcat_create_pickup_request_record($pickup_request_type, $customId, $patronId, $branch, $timeSlot, $pickupLocation, $pickupDate, $contactEmail, $contactSMS, $contactPhone, $lockerCode) {
+  function arborcat_create_pickup_request_record($pickup_request_type, $customId, $patron_id, $branch, $timeSlot, $pickupLocation, $pickupDate, $contactEmail, $contactSMS, $contactPhone, $lockerCode) {
     // create arborcat_patron_pickup_request records for each of the selected holds
     $db = \Drupal::database();
  
@@ -330,7 +330,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
         $dbaction = $db->insert('arborcat_patron_pickup_request')->fields([
           'requestType'   => $pickup_request_type,
           'requestId'     => $customId,
-          'patronId'      => $patronId,
+          'patronId'      => $patron_id,
           'branch'        => (int) $branch,
           'timeSlot'      => $timeSlot,
           'pickupLocation' => $pickupLocation,
@@ -352,11 +352,11 @@ function arborcat_patron_fines_expired($fines, $patron) {
     }
   }
 
-  function barcode_From_patronId($patronId) {
+  function barcode_From_patronId($patron_id) {
     $api_key = \Drupal::config('arborcat.settings')->get('api_key');
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
     $guzzle = \Drupal::httpClient();
-    $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
+    $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patron_id";
  
     try {
       $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
@@ -386,9 +386,9 @@ function arborcat_patron_fines_expired($fines, $patron) {
       return "";
      }
     if ($json) {
-      $patronId =  $json->pid;
+      $patron_id =  $json->pid;
 
-      return $patronId;
+      return $patron_id;
     } else {
       return "";
     }
@@ -421,7 +421,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
 
       if (count($assocResults) > 0) {
         $barcode = $assocResults['barcode'];
-        $patronId = (strlen($barcode) == 14) ? patronId_from_barcode($barcode) : NULL;
+        $patron_id = (strlen($barcode) == 14) ? patronId_from_barcode($barcode) : NULL;
         $branchNameArray = explode(" ", $assocResults['delivery_method']);
         if ($branchNameArray[0] == 'Mail') {  // Mail to Patron option - no pickup request should be created
           $resultMessage = 'SUCCESS';
@@ -441,7 +441,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
           $result = arborcat_create_pickup_request_record(
             $pickup_request_type,
             $customPickupRequestId,
-            $patronId,
+            $patron_id,
             $branch,
             $timeslot,
             $pickupLocation,

--- a/arborcat.module
+++ b/arborcat.module
@@ -352,12 +352,20 @@ function arborcat_patron_fines_expired($fines, $patron) {
     }
   }
 
-  function barcodeFromPatronId($patronId) {
+  function barcode_From_patronId($patronId) {
     $api_key = \Drupal::config('arborcat.settings')->get('api_key');
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
     $guzzle = \Drupal::httpClient();
     $requestURL = "$api_url/patron?apikey=$api_key&pnum=$patronId";
-    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+ 
+    try {
+      $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+
+     } catch (Exception $e) {
+
+      return "";
+    }
+
     if ($json) {
       $barcode =  $json->evg_user->card->barcode;
 
@@ -367,12 +375,16 @@ function arborcat_patron_fines_expired($fines, $patron) {
     }
   }
 
-  function patronIdFromBarcode($barcode) {
+  function patronId_from_barcode($barcode) {
     $api_key = \Drupal::config('arborcat.settings')->get('api_key');
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
     $guzzle = \Drupal::httpClient();
     $requestURL = "$api_url/patron?apikey=$api_key&barcode=$barcode";
-    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+     try {
+       $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+     } catch (Exception $e) {
+      return "";
+     }
     if ($json) {
       $patronId =  $json->pid;
 
@@ -409,7 +421,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
 
       if (count($assocResults) > 0) {
         $barcode = $assocResults['barcode'];
-        $patronId = (strlen($barcode) == 14) ? patronIdFromBarcode($barcode) : NULL;
+        $patronId = (strlen($barcode) == 14) ? patronId_from_barcode($barcode) : NULL;
         $branchNameArray = explode(" ", $assocResults['delivery_method']);
         if ($branchNameArray[0] == 'Mail') {  // Mail to Patron option - no pickup request should be created
           $resultMessage = 'SUCCESS';
@@ -452,3 +464,18 @@ function arborcat_patron_fines_expired($fines, $patron) {
 
     return $resultMessage;
   }
+
+  /*
+* Debugging routine to log to the <root folder>/LWKLWK.log IN arborcat.module
+*/
+function dblog(...$thingsToLog) {
+  $lineToLog = '';
+  foreach ($thingsToLog as $item) {
+    $lineToLog = $lineToLog . ' ' . print_r($item, TRUE);
+  }
+  // prepend date/time onto log line
+  $nowDateTime = new DrupalDateTime();
+  $dateTimeString = (string) $nowDateTime->format('Y-m-d H:i:s');
+  $completeLine = '[' . $dateTimeString . '] ' . $lineToLog . "\n";
+  error_log($completeLine, 3, "LWKLWK.log");
+}

--- a/arborcat.module
+++ b/arborcat.module
@@ -319,6 +319,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
         ->condition('requestId', $customId, '=');
       $results = $query->execute()->fetchCol();
     } catch (Exception $e) {
+      drupal_set_message('An error occurred creating this pickup request. Please try again');
       return -1;
     }
     // If a record exists containing the $customId, just return the id of the record, otherwise insert a new record with the customId and return the $id of the new record
@@ -345,6 +346,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
 
         return $id;
       } catch (Exception $e) {
+        drupal_set_message('An error occurred saving this pickup request. Please try again');
         $txn->rollBack();
 
         return -1;
@@ -353,6 +355,7 @@ function arborcat_patron_fines_expired($fines, $patron) {
   }
 
   function barcode_From_patronId($patron_id) {
+    $return_val = "";
     $api_key = \Drupal::config('arborcat.settings')->get('api_key');
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
     $guzzle = \Drupal::httpClient();
@@ -362,20 +365,22 @@ function arborcat_patron_fines_expired($fines, $patron) {
       $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
 
      } catch (Exception $e) {
+      // Note no error message is not set here - check in made in calling methods for a valid barcode and
+       // an error message is displayed to the user there.
 
-      return "";
+      return $return_val;
     }
 
     if ($json) {
       $barcode =  $json->evg_user->card->barcode;
-
-      return $barcode;
-    } else {
-      return "";
+      $return_val = $barcode;
     }
+
+    return $return_val;
   }
 
   function patronId_from_barcode($barcode) {
+    $return_val = "";
     $api_key = \Drupal::config('arborcat.settings')->get('api_key');
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
     $guzzle = \Drupal::httpClient();
@@ -383,15 +388,18 @@ function arborcat_patron_fines_expired($fines, $patron) {
      try {
        $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
      } catch (Exception $e) {
-      return "";
+       // Note no error message is not set here - check in made in calling method for a valid patron_id and 
+       // an error message is displayed to the user there.
+
+     return $return_val;
      }
+
     if ($json) {
       $patron_id =  $json->pid;
-
-      return $patron_id;
-    } else {
-      return "";
+      $return_val = $patron_id;
     }
+
+    return $return_val;
   }
   
   function arborcat_custom_pickup_request($pickup_request_type, $customPickupRequestId) {

--- a/arborcat.module
+++ b/arborcat.module
@@ -385,7 +385,7 @@ function arborcat_patron_id_from_barcode($barcode) {
   $guzzle = \Drupal::httpClient();
   $request_url = "$api_url/patron?apikey=$api_key&barcode=$barcode";
   try {
-    $json = json_decode($guzzle->get($requestURL)->getBody()->getContents());
+    $json = json_decode($guzzle->get($request_url)->getBody()->getContents());
   } catch (Exception $e) {
     // Note no error message is not set here - check in made in calling method for a valid patron_id and
     // an error message is displayed to the user there.

--- a/arborcat_lists/arborcat_lists.module
+++ b/arborcat_lists/arborcat_lists.module
@@ -162,8 +162,8 @@ function arborcat_lists_update_user_history($uid, $seed_only = FALSE) {
       /* SG2020 NO POINTS FOR CHECKOUTS =================================================
       if (\Drupal::moduleHandler()->moduleExists('summergame')) {
         if (\Drupal::config('summergame.settings')->get('summergame_points_enabled')) {
-          $userData = \Drupal::service('user.data');
-          if ($sg_active_pid = $userData->get('summergame', $uid, 'sg_active_pid')) {
+          $user_data = \Drupal::service('user.data');
+          if ($sg_active_pid = $user_data->get('summergame', $uid, 'sg_active_pid')) {
             $player = summergame_player_load($sg_active_pid);
           }
           else {
@@ -192,9 +192,9 @@ function arborcat_lists_update_user_history($uid, $seed_only = FALSE) {
     }
 
     // Save checkouts to checkout cache
-    $userData = \Drupal::service('user.data');
-    $userData->delete('arborcat_lists', $uid, 'cc_bnums');
-    $userData->set('arborcat_lists', $uid, 'cc_bnums', $co_bnums);
+    $user_data = \Drupal::service('user.data');
+    $user_data->delete('arborcat_lists', $uid, 'cc_bnums');
+    $user_data->set('arborcat_lists', $uid, 'cc_bnums', $co_bnums);
   }
 }
 

--- a/js/pickuprequest-functions.js
+++ b/js/pickuprequest-functions.js
@@ -26,10 +26,8 @@
               var id = 'edit-item-table' + '-' + i;
               var checkeditem = $('#' + id).is(':checked');
               var currentRow = $("#edit-item-table tbody tr");
-              var name = currentRow.find("td:eq(0)").text(); // get current row 1st TD value
-              var branch = currentRow.find("td:eq(1)").text(); // get current row 2nd TD
-              var artPrintTool = currentRow.find("td:eq(2)").text(); // get current row 3rd TD
-              if (artPrintTool && checkeditem) {
+              var artPrintOrTool = currentRow.find("td:eq(3)").text(); // get current row 4th column
+              if (artPrintOrTool && checkeditem) {
                 returnflag = true;
               }
             }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -510,9 +510,7 @@ class DefaultController extends ControllerBase {
                           $hold_shelf_expire_date = date_format($tomorrow, 'Y-m-d');
                       }
                       // Now update the hold_request expire_time in Evergreen
-                      $date_time_now = new DateTime('now');
-                      $cancel_time = $date_time_now->format('Y-m-d H:i:s');
-                      $url = "$api_url/patron/$selfCheckApi_key-$patron_barcode/update_hold/" . $cancelRecord->requestId . "?shelf_expire_time=$hold_shelf_expire_date 23:59:59&cancel_time=$cancel_time";
+                      $url = "$api_url/patron/$selfCheckApi_key-$patron_barcode/update_hold/" . $cancelRecord->requestId . "?shelf_expire_time=$hold_shelf_expire_date 23:59:59";
                       $updated_hold = $guzzle->get($url)->getBody()->getContents();
                       $response['success'] = 'Pickup Request Canceled';
                   } else {
@@ -533,7 +531,7 @@ class DefaultController extends ControllerBase {
 
   private function validateTransaction($pnum, $encrypted_barcode) {
     $returnval = FALSE;
-    $barcode =  barcode_From_patronId($pnum);
+    $barcode =  barcodeFromPatronId($pnum);
     if (14 == strlen($barcode)) {
         $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
         $hashedBarcode = md5($pickup_requests_salt . $barcode);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -464,7 +464,7 @@ class DefaultController extends ControllerBase {
   public function pickup_request($pnum, $encrypted_barcode, $loc) {
       $mode = \Drupal::request()->query->get('mode');
       $requestPickup_html = '';
-      if ($this->validateTransaction($pnum, $encrypted_barcode)) {
+      if ($this->validate_transaction($pnum, $encrypted_barcode)) {
           $requestPickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $pnum, $loc, $mode);
       } else {
           drupal_set_message('The Pickup Request could not be processed');
@@ -484,7 +484,7 @@ class DefaultController extends ControllerBase {
 
   public function cancel_pickup_request($patron_barcode, $encrypted_request_id, $hold_shelf_expire_date) {
       $patron_id = patronId_from_barcode($patron_barcode);
-      $cancelRecord = $this->findRecordToCancel($patron_id, $encrypted_request_id);
+      $cancelRecord = $this->find_record_to_cancel($patron_id, $encrypted_request_id);
       if (count($cancelRecord) > 0) {
           $db = \Drupal::database();
           $guzzle = \Drupal::httpClient();
@@ -492,7 +492,7 @@ class DefaultController extends ControllerBase {
           $api_url = \Drupal::config('arborcat.settings')->get('api_url');
           $selfCheckApi_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
           
-          // check date is for tomorrow or later - NOTE this is overkill - the query inside 'findRecordToCancel' method checks for date > todays date.
+          // check date is for tomorrow or later - NOTE this is overkill - the query inside 'find_record_to_cancel' method checks for date > todays date.
           $today = (new DateTime("now", new DateTimeZone('UTC')));
           $today->setTime(0,0,0);
           $tomorrow = $today->modify('+1 day');
@@ -529,9 +529,9 @@ class DefaultController extends ControllerBase {
       return new JsonResponse($response);
   }
 
-  private function validateTransaction($pnum, $encrypted_barcode) {
+  private function validate_transaction($pnum, $encrypted_barcode) {
     $returnval = FALSE;
-    $barcode =  barcodeFromPatronId($pnum);
+    $barcode =  barcode_from_patronId($pnum);
     if (14 == strlen($barcode)) {
         $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
         $hashedBarcode = md5($pickup_requests_salt . $barcode);
@@ -542,7 +542,7 @@ class DefaultController extends ControllerBase {
     return $returnval;
   }
 
-  private function findRecordToCancel($patronId, $encrypted_holdId) {
+  private function find_record_to_cancel($patronId, $encrypted_holdId) {
       $returnRecord = [];
       // get all the pickupRequest records for the patron
       $today = (new DateTime("now"));

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -436,9 +436,9 @@ class DefaultController extends ControllerBase {
           }
           else {
               if (strlen($patronId) > 0) {
-                  $barcode =  barcodeFromPatronId($patronId);
+                  $barcode =  barcode_From_patronId($patronId);
               } else {
-                  $patronId = patronIdFromBarcode($barcode);
+                  $patronId = patronId_from_barcode($barcode);
               }
               if (14 === strlen($barcode)) {
                 if (strlen($row) > 0) {
@@ -483,7 +483,7 @@ class DefaultController extends ControllerBase {
   }
 
   public function cancel_pickup_request($patron_barcode, $encrypted_request_id, $hold_shelf_expire_date) {
-      $patron_id = patronIdFromBarcode($patron_barcode);
+      $patron_id = patronId_from_barcode($patron_barcode);
       $cancelRecord = $this->findRecordToCancel($patron_id, $encrypted_request_id);
       if (count($cancelRecord) > 0) {
           $db = \Drupal::database();
@@ -510,7 +510,9 @@ class DefaultController extends ControllerBase {
                           $hold_shelf_expire_date = date_format($tomorrow, 'Y-m-d');
                       }
                       // Now update the hold_request expire_time in Evergreen
-                      $url = "$api_url/patron/$selfCheckApi_key-$patron_barcode/update_hold/" . $cancelRecord->requestId . "?shelf_expire_time=$hold_shelf_expire_date 23:59:59";
+                      $date_time_now = new DateTime('now');
+                      $cancel_time = $date_time_now->format('Y-m-d H:i:s');
+                      $url = "$api_url/patron/$selfCheckApi_key-$patron_barcode/update_hold/" . $cancelRecord->requestId . "?shelf_expire_time=$hold_shelf_expire_date 23:59:59&cancel_time=$cancel_time";
                       $updated_hold = $guzzle->get($url)->getBody()->getContents();
                       $response['success'] = 'Pickup Request Canceled';
                   } else {
@@ -531,7 +533,7 @@ class DefaultController extends ControllerBase {
 
   private function validateTransaction($pnum, $encrypted_barcode) {
     $returnval = FALSE;
-    $barcode =  barcodeFromPatronId($pnum);
+    $barcode =  barcode_From_patronId($pnum);
     if (14 == strlen($barcode)) {
         $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
         $hashedBarcode = md5($pickup_requests_salt . $barcode);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -384,9 +384,9 @@ class DefaultController extends ControllerBase {
           $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
 
           foreach ($hold_locations as $loc) {
-            $locationName = ($loc < 110) ? $locations->{$loc} : 'melcat';
+            $location_name = ($loc < 110) ? $locations->{$loc} : 'melcat';
             $url = $this->create_pickup_url($patron_id, $barcode, $loc);
-            array_push($location_urls, ['url'=>$url, 'loc'=>$loc, 'locname'=>$locationName]);
+            array_push($location_urls, ['url'=>$url, 'loc'=>$loc, 'locname'=>$location_name]);
           }
         }
       } else {
@@ -424,13 +424,13 @@ class DefaultController extends ControllerBase {
     $patron_id = \Drupal::request()->query->get('patronid');
     $location = \Drupal::request()->query->get('location');
     $request_id = \Drupal::request()->query->get('requestid');
-    
+
     if (strlen($location) == 3) {
       //$locations = pickupLocations($location);
     } else {
       $location = '102';
     }
-    
+
     $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
 
     if (strlen($request_id) > 0) {
@@ -448,7 +448,7 @@ class DefaultController extends ControllerBase {
       }
       $encrypted_barcode = md5($pickup_requests_salt . $barcode);
       $return_val = '<h2>' . $patron_id .' -> '. $barcode . ' -> ' . $encrypted_barcode . '</h2><br>';
-  
+
       $host = 'http://nginx.docker.localhost:8000';
       $link = $host . '/pickuprequest/' . $patron_id . '/'. $encrypted_barcode . '/' . $location;
       $html = '<br><a href="' . $link . '" target="_blank">' . $link  . '</a>';
@@ -482,9 +482,9 @@ class DefaultController extends ControllerBase {
   }
 
   public function custom_pickup_request($pickup_request_type, $overload_parameter) {
-    $resultMessage = arborcat_custom_pickup_request($pickup_request_type, $overload_parameter);
+    $result_message = arborcat_custom_pickup_request($pickup_request_type, $overload_parameter);
 
-    return new JsonResponse($resultMessage);
+    return new JsonResponse($result_message);
   }
 
   public function cancel_pickup_request($patron_barcode, $encrypted_request_id, $hold_shelf_expire_date) {
@@ -496,7 +496,7 @@ class DefaultController extends ControllerBase {
       $api_key = \Drupal::config('arborcat.settings')->get('api_key');
       $api_url = \Drupal::config('arborcat.settings')->get('api_url');
       $self_check_api_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
-      
+
       // check date is for tomorrow or later - NOTE this is overkill - the query inside 'find_record_to_cancel' method checks for date > todays date.
       $today = (new DateTime("now", new DateTimeZone('UTC')));
       $today->setTime(0, 0, 0);
@@ -530,7 +530,7 @@ class DefaultController extends ControllerBase {
     } else {
       $response['error'] = "The Pickup Request cancellation could not be completed";
     }
-    
+
     return new JsonResponse($response);
   }
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -469,7 +469,7 @@ class DefaultController extends ControllerBase {
     if ($this->validate_transaction($pnum, $encrypted_barcode)) {
       $request_pickup_html = \Drupal::formBuilder()->getForm('Drupal\arborcat\Form\UserPickupRequestForm', $pnum, $loc, $mode, $exclusion_marker_string);
     } else {
-      drupal_set_message('The Pickup Request could not be processed');
+      drupal_set_message('The Pickup Request could not be processed', 'error');
     }
     $render[] = [
       '#theme' => 'pickup_request_form',

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -364,7 +364,7 @@ class DefaultController extends ControllerBase {
       if (!isset($eligibleHolds['error'])) {
         if (count($eligibleHolds) > 0) {
           // Get the patron ID from the first hold object in $eligibleHolds. NOTE - this starts at offset [1]
-          $patronId = $eligibleHolds[1]['usr'];
+          $patron_id = $eligibleHolds[1]['usr'];
           $holdLocations = [];
           // spin through the eligible holds and get the locations
           foreach ($eligibleHolds as $holdobj) {
@@ -378,7 +378,7 @@ class DefaultController extends ControllerBase {
 
           foreach ($holdLocations as $loc) {
               $locationName = ($loc < 110) ? $locations->{$loc} : 'melcat';
-              $url = $this->createPickupURL($patronId, $barcode, $loc);
+              $url = $this->createPickupURL($patron_id, $barcode, $loc);
               array_push($locationURLs, ['url'=>$url, 'loc'=>$loc, 'locname'=>$locationName]);
           }
         }
@@ -398,28 +398,28 @@ class DefaultController extends ControllerBase {
     return $render;
   }
 
-  private function createPickupURL($patronId, $barcode, $location) {
+  private function createPickupURL($patron_id, $barcode, $location) {
       $html = '';
       $pickup_requests_salt = \Drupal::config('arborcat.settings')->get('pickup_requests_salt');
       $encryptedBarcode = md5($pickup_requests_salt . $barcode);
       $host = \Drupal::request()->getHost();
-      $link = 'https://'. $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
+      $link = 'https://'. $host . '/pickuprequest/' . $patron_id . '/'. $encryptedBarcode . '/' . $location;
       return $link;
   }
 
   public function pickup_test() {
       $returnval = '';
       $barcode = \Drupal::request()->query->get('barcode');
-      $patronId = \Drupal::request()->query->get('patronid');
+      $patron_id = \Drupal::request()->query->get('patronid');
       $location = \Drupal::request()->query->get('location');
       $seeddb = \Drupal::request()->query->get('seeddb');
       $requestId = \Drupal::request()->query->get('requestid');
       
       if (strlen($seeddb) > 0) {
-          $this->addPickupRequest($patronId, '$9999901', '104', '2020-06-17', '0', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-          $this->addPickupRequest($patronId, '$9999902', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-          $this->addPickupRequest($patronId, '$9999903', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
-          $this->addPickupRequest($patronId, '$9999904', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+          $this->addPickupRequest($patron_id, '$9999901', '104', '2020-06-17', '0', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+          $this->addPickupRequest($patron_id, '$9999902', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+          $this->addPickupRequest($patron_id, '$9999903', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
+          $this->addPickupRequest($patron_id, '$9999904', '104', '2020-06-17', '1', '1003', 'kirchmeierl@aadl.org', '734-327-4218', '734-417-7747');
       } else {
           if (strlen($location) == 3) {
               //$locations = pickupLocations($location);
@@ -435,20 +435,20 @@ class DefaultController extends ControllerBase {
               $returnval .= 'pickup_requests_salt: ' . $pickup_requests_salt . '</p><br>';
           }
           else {
-              if (strlen($patronId) > 0) {
-                  $barcode =  barcode_From_patronId($patronId);
+              if (strlen($patron_id) > 0) {
+                  $barcode =  barcode_From_patronId($patron_id);
               } else {
-                  $patronId = patronId_from_barcode($barcode);
+                  $patron_id = patronId_from_barcode($barcode);
               }
               if (14 === strlen($barcode)) {
                 if (strlen($row) > 0) {
                         $barcode = $row;
                     }
                 $encryptedBarcode = md5($pickup_requests_salt . $barcode);
-                $returnval = '<h2>' . $patronId .' -> '. $barcode . ' -> ' . $encryptedBarcode . '</h2><br>';
+                $returnval = '<h2>' . $patron_id .' -> '. $barcode . ' -> ' . $encryptedBarcode . '</h2><br>';
             
                 $host = 'http://nginx.docker.localhost:8000';
-                $link = $host . '/pickuprequest/' . $patronId . '/'. $encryptedBarcode . '/' . $location;
+                $link = $host . '/pickuprequest/' . $patron_id . '/'. $encryptedBarcode . '/' . $location;
                 $html2 = '<br><a href="' . $link . '" target="_blank">' . $link  . '</a>';
 
                 $returnval .= $html2;
@@ -542,7 +542,7 @@ class DefaultController extends ControllerBase {
     return $returnval;
   }
 
-  private function find_record_to_cancel($patronId, $encrypted_holdId) {
+  private function find_record_to_cancel($patron_id, $encrypted_holdId) {
       $returnRecord = [];
       // get all the pickupRequest records for the patron
       $today = (new DateTime("now"));
@@ -551,7 +551,7 @@ class DefaultController extends ControllerBase {
       $db = \Drupal::database();
       $query = $db->select('arborcat_patron_pickup_request', 'appr');
       $query->fields('appr', ['id', 'patronId', 'requestId', 'pickupDate']);
-      $query->condition('patronId', $patronId);
+      $query->condition('patronId', $patron_id);
       $query->condition('pickupDate', $todayDateString, '>');
       $results = $query->execute()->fetchAll();        
       if (count($results) > 0) {

--- a/src/Form/LockerRequestForm.php
+++ b/src/Form/LockerRequestForm.php
@@ -26,9 +26,9 @@ class LockerRequestForm extends FormBase{
 		$api_key = $account->get('field_api_key')->value;
 		$api_url = \Drupal::config('arborcat.settings')->get('api_url');
 		$patron_info = json_decode($guzzle->get("$api_url/patron/$api_key/get")->getBody()->getContents(),true);
-		$locker_holds = json_decode($guzzle->get("$api_url/patron/$api_key/holds")->getBody()->getContents(),true);	
+		$locker_holds = json_decode($guzzle->get("$api_url/patron/$api_key/holds")->getBody()->getContents(),true);
 		$eligible_holds=[];
-		//start at 1 to avoid issue with eligible holds array not being zero-based 
+		//start at 1 to avoid issue with eligible holds array not being zero-based
 		$i=1;
 
 		if(count($locker_holds)){
@@ -63,7 +63,7 @@ class LockerRequestForm extends FormBase{
 				'#type'=>'value',
 				'#default_value'=>$uid
 			];
-		$form['explanation'] = [	
+		$form['explanation'] = [
 			'#markup'=>"<h2>$branch Locker Request Form</h2>" .
 			"Select items below to request that they be put into a locker:"
 		];
@@ -79,7 +79,7 @@ class LockerRequestForm extends FormBase{
 			'#multiple'=>'true',
 			'#empty'=>"You have no holds ready for pickup."
 		];
-		
+
 		$form['explanationcont']=[
 			'#markup'=>
 			"<div>" .
@@ -144,7 +144,7 @@ class LockerRequestForm extends FormBase{
 			$time = strftime(time());
 			$redis_query = $time . "#" . $branch;
 			$redis->lPush('lockerRequests',$redis_query);
-			
+
 			//check for holidays
 			$easter_ts = easter_date();
     	$easter_date = date('md', $easter_ts);
@@ -219,7 +219,7 @@ class LockerRequestForm extends FormBase{
 			foreach($holds as $title){
 				$email_message = $email_message.$title['Title']."\r\n";
 			}
-			$mailManager = \Drupal::service('plugin.manager.mail');
+			$mail_manager = \Drupal::service('plugin.manager.mail');
 			mail($email_to,$email_subject,$email_message,$email_headers);
 		}
 	}

--- a/src/Form/LockerRequestForm.php
+++ b/src/Form/LockerRequestForm.php
@@ -219,7 +219,6 @@ class LockerRequestForm extends FormBase{
 			foreach($holds as $title){
 				$email_message = $email_message.$title['Title']."\r\n";
 			}
-			$mail_manager = \Drupal::service('plugin.manager.mail');
 			mail($email_to,$email_subject,$email_message,$email_headers);
 		}
 	}

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -124,18 +124,20 @@ class UserPickupRequestForm extends FormBase {
     if (!isset($cancel_holds)) {
       $starting_day_offset = \Drupal::config('arborcat.settings')->get('starting_day_offset');
       $number_of_pickup_days = \Drupal::config('arborcat.settings')->get('number_of_pickup_days');
-      $starting_day = new DateTime('+' . $starting_day_offset . ' day');
+      $starting_day = new DateTime();
+      $starting_day->modify('+1 day');
 
       // SPECIAL CASE for library-wide closure in order to force starting date to be the first day after the closure if
       // this form is being opened whilst the closure is in operation
-      $opening_date = new DateTime('20-12-09');
+      // $opening_date = new DateTime('20-12-09');
 
-      if ($starting_day < $opening_date) {
-        $starting_day = $opening_date;
-      }
+      // if ($starting_day < $opening_date) {
+      //   $starting_day = $opening_date;
+      // }
 
       $starting_day_plus_pickup_days = clone $starting_day;
-      $starting_day_plus_pickup_days->modify('+' . $number_of_pickup_days - 1 . ' days');
+      $modifystring = '+' . $number_of_pickup_days - 1 . ' days';
+      $starting_day_plus_pickup_days->modify($modifystring);
 
       $pickup_dates_data = arborcat_get_pickup_dates($request_location, $starting_day->format('Y-m-d'), $starting_day_plus_pickup_days->format('Y-m-d'));
       $form_state->set('exclusionData', $pickup_dates_data);
@@ -158,20 +160,17 @@ class UserPickupRequestForm extends FormBase {
       $pickup_options =  [];
       $i = 1;
       foreach ($pickup_locations_for_request as $location_object) {
-        $add_location = TRUE;
-        if (TRUE == $add_location) {
-          // need to append the times in human readable form
-          $start_time_object = new dateTime($location_object->timePeriodStart);
-          $end_time_Object = new dateTime($location_object->timePeriodEnd);
-          $time_period_formatted = ', ' . date_format($start_time_object, "ga") . ' to ' . date_format($end_time_Object, "ga");
-          // check if this is an overnight time period
-          if ($end_time_Object < $start_time_object) {
-            $time_period_formatted .= ' (overnight)';
-          }
-          $name_plus_time_period = $location_object->locationName . $time_period_formatted;
-          // concatenate the locationId and the timeslot into the key
-          $pickup_options["$location_object->locationId-$location_object->timePeriod"] = $name_plus_time_period;
+        // need to append the times in human readable form
+        $start_time_object = new dateTime($location_object->timePeriodStart);
+        $end_time_Object = new dateTime($location_object->timePeriodEnd);
+        $time_period_formatted = ', ' . date_format($start_time_object, "ga") . ' to ' . date_format($end_time_Object, "ga");
+        // check if this is an overnight time period
+        if ($end_time_Object < $start_time_object) {
+          $time_period_formatted .= ' (overnight)';
         }
+        $name_plus_time_period = $location_object->locationName . $time_period_formatted;
+        // concatenate the locationId and the timeslot into the key
+        $pickup_options["$location_object->locationId-$location_object->timePeriod"] = $name_plus_time_period;
       }
       $form['pickup_type'] = [
               '#prefix' => '<div class="l-inline-b side-by-side-form">',

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -402,7 +402,6 @@ class UserPickupRequestForm extends FormBase {
       foreach ($holds as $title) {
         $email_message = $email_message.$title['Title']."\r\n";
       }
-      $mail_manager = \Drupal::service('plugin.manager.mail');
       mail($email_to, $email_subject, $email_message, $email_headers);
     }
   }

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -319,7 +319,8 @@ class UserPickupRequestForm extends FormBase {
 
       foreach ($holds as $hold) {
         if ($cancel_holds) {
-          $cancel_time = date('Y-m-d');
+          $date_time_now = new DateTime('now');
+          $cancel_time = $date_time_now->format('Y-m-d H:i:s');
           $guzzle->get("$api_url/patron/$selfCheckApi_key-$patron_barcode/update_hold/" . $hold['holdId'] . "?cancel_time=$cancel_time&cancel_cause=6")->getBody()->getContents();
         } else {
           // set the expire date for each selected hold

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -24,7 +24,7 @@ class UserPickupRequestForm extends FormBase {
     $account = \Drupal\user\Entity\User::load($uid);
     $patron_barcode = $patron_info['evg_user']['card']['barcode'];
     $eligible_holds = arborcat_load_patron_eligible_holds($patron_barcode, $request_location);
-  
+
     // Get the locations
     $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
     $location_name = $locations->$request_location;
@@ -120,12 +120,12 @@ class UserPickupRequestForm extends FormBase {
             '#suffix' => '</div>',
             '#default_value' => $selection
         ];
- 
+
     if (!isset($cancel_holds)) {
       $starting_day_offset = \Drupal::config('arborcat.settings')->get('starting_day_offset');
       $number_of_pickup_days = \Drupal::config('arborcat.settings')->get('number_of_pickup_days');
       $starting_day = new DateTime('+' . $starting_day_offset . ' day');
-      
+
       // SPECIAL CASE for library-wide closure in order to force starting date to be the first day after the closure if
       // this form is being opened whilst the closure is in operation
       $opening_date = new DateTime('20-12-09');
@@ -139,7 +139,7 @@ class UserPickupRequestForm extends FormBase {
 
       $pickup_dates_data = arborcat_get_pickup_dates($request_location, $starting_day->format('Y-m-d'), $starting_day_plus_pickup_days->format('Y-m-d'));
       $form_state->set('exclusionData', $pickup_dates_data);
-      
+
       $pickup_dates =[];
       foreach ($pickup_dates_data as $data_item_key => $data_item_value) {
         $append_string =  ($data_item_value['date_exclusion_data'] != NULL) ? ' ' . $exclusion_marker_string : '';
@@ -158,8 +158,8 @@ class UserPickupRequestForm extends FormBase {
       $pickup_options =  [];
       $i = 1;
       foreach ($pickup_locations_for_request as $location_object) {
-        $addLocation = TRUE;
-        if (TRUE == $addLocation) {
+        $add_location = TRUE;
+        if (TRUE == $add_location) {
           // need to append the times in human readable form
           $start_time_object = new dateTime($location_object->timePeriodStart);
           $end_time_Object = new dateTime($location_object->timePeriodEnd);
@@ -252,7 +252,7 @@ class UserPickupRequestForm extends FormBase {
       $pickup_point = (int) explode('-', $form_state->getValue('pickup_type'))[0];
       if (in_array($pickup_point, $lockers)) {                                        // check if it's a locker pickup request
         $pickup_date =  $form_state->getValue('pickup_date');
-              
+
         if (!$form_state->getValue('phone')) {
           $form_state->setErrorByName('phone', t('A phone number is required for lockers so we can generate your locker code'));
         }
@@ -263,7 +263,7 @@ class UserPickupRequestForm extends FormBase {
                     ->condition('locationId', $pickup_point, '=')
                     ->execute();
         $pickup_location = $query->fetch();
-                
+
         $patron_id = $form_state->getValue('pnum');
         $avail = arborcat_check_locker_availability($pickup_date, $pickup_location, $patron_id);
 
@@ -332,7 +332,7 @@ class UserPickupRequestForm extends FormBase {
       $api_key = \Drupal::config('arborcat.settings')->get('api_key');
       $api_url = \Drupal::config('arborcat.settings')->get('api_url');
       $self_check_api_key = \Drupal::config('arborcat.settings')->get('selfcheck_key');
- 
+
       // Get the locations
       $locations = json_decode($guzzle->get("$api_url/locations")->getBody()->getContents());
 
@@ -373,7 +373,7 @@ class UserPickupRequestForm extends FormBase {
       if ($error_count == 0) {
         $submit_message = ($cancel_holds ? 'Your requests were successfully canceled' : 'Pickup appointment scheduled for ' . date('F j', strtotime($pickup_date)) . ' at ' . $locations->{$branch});
         $messenger->addMessage($submit_message);
-  
+
         $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
         $uid = $user->id();
         $url = \Drupal\Core\Url::fromRoute('entity.user.canonical', ['user'=>$user->id()]);
@@ -403,7 +403,7 @@ class UserPickupRequestForm extends FormBase {
       foreach ($holds as $title) {
         $email_message = $email_message.$title['Title']."\r\n";
       }
-      $mailManager = \Drupal::service('plugin.manager.mail');
+      $mail_manager = \Drupal::service('plugin.manager.mail');
       mail($email_to, $email_subject, $email_message, $email_headers);
     }
   }

--- a/src/Form/UserPickupRequestForm.php
+++ b/src/Form/UserPickupRequestForm.php
@@ -15,11 +15,11 @@ class UserPickupRequestForm extends FormBase {
     return 'user_pickup_request_form';
   }
 
-  public function buildForm(array $form, FormStateInterface $form_state, string $patronId = NULL, string $requestLocation = NULL, string $mode = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, string $patron_id = NULL, string $requestLocation = NULL, string $mode = NULL) {
     $guzzle = \Drupal::httpClient();
     $api_key = \Drupal::config('arborcat.settings')->get('api_key');
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
-    $patron_info = json_decode((string) $guzzle->get("$api_url/patron?apikey=$api_key&pnum=$patronId")->getBody()->getContents(), TRUE);
+    $patron_info = json_decode((string) $guzzle->get("$api_url/patron?apikey=$api_key&pnum=$patron_id")->getBody()->getContents(), TRUE);
     $uid = $patron_info['evg_user']['card']['id'];
     $account = \Drupal\user\Entity\User::load($uid);
     $patron_barcode = $patron_info['evg_user']['card']['barcode'];
@@ -47,7 +47,7 @@ class UserPickupRequestForm extends FormBase {
 
     $form['pnum'] = [
             '#type' => 'hidden',
-            '#default_value' => $patronId
+            '#default_value' => $patron_id
         ];
 
     $form['patron_barcode'] = [
@@ -241,8 +241,8 @@ class UserPickupRequestForm extends FormBase {
                     ->execute();
         $pickup_location = $query->fetch();
                 
-        $patronId = $form_state->getValue('pnum');
-        $avail = arborcat_check_locker_availability($pickup_date, $pickup_location, $patronId);
+        $patron_id = $form_state->getValue('pnum');
+        $avail = arborcat_check_locker_availability($pickup_date, $pickup_location, $patron_id);
 
         // if no avail lockers, set form error
         if (!$avail) {

--- a/src/Plugin/Block/HoldsBlock.php
+++ b/src/Plugin/Block/HoldsBlock.php
@@ -54,7 +54,8 @@ class HoldsBlock extends BlockBase {
       $output .= '</tr></thead><tbody>';
 
       // used to cancel a hold by updating canceled_time field
-      $cur_time = date('Y-m-d');
+      $date_time_now = new DateTime('now');
+      $cur_time = $date_time_now->format('Y-m-d H:i:s');
       // build location change options for individual and modify selected
       $locOptions = '';
       foreach ($locations as $n => $loc) {


### PR DESCRIPTION
Added timestamp string to the cancel_time field when a hold_request is cancelled. Previously, only the date string was being passed. This is initiated if the user clicks on the "Cancel Holds" email link or from the arborcat holdsblock.
This has been tested on pinkeye and timezone settings have been verified as being correct.  Currently this is installed on pinkeye and is available for further testing if needed. 