### PR TITLE
Fix contact sms error

### DIFF
--- a/arborcat.module
+++ b/arborcat.module
@@ -446,7 +446,6 @@ function arborcat_custom_pickup_request($pickup_request_type, $custom_pickup_req
           $time_slot,
           $pickup_location,
           $pickup_date,
-          $patron_email,
           (in_array('email', array_map('strtolower', $notification_options))) ? $patron_email : NULL,
           (in_array('text', array_map("strtolower", $notification_options))) ? $patron_phone : NULL,
           (in_array('phone call', array_map("strtolower", $notification_options))) ? $patron_phone : NULL,


### PR DESCRIPTION
Fixed the issue for custom pickup requests (print proces, shelf service) where the contactSMS field is being incorrectly filled with the email address rather than the phone number supplied by the patron.