### PR TITLE
Cancel appointments mel cat#159

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -391,6 +391,7 @@ class DefaultController extends ControllerBase {
         $display_date = date('D n/d', strtotime($exclude->dateStart));
         $blocks[$locations->{$exclude->locationId}][] = "$display_date ($exclude->notes)";
       }
+      $blocks_msg = '';
       foreach ($blocks as $key => $block) {
         $blocks[$key] = implode(', ', $block);
         $blocks_msg .= "$key: " . implode(', ', $block) . '<br>';
@@ -486,6 +487,7 @@ class DefaultController extends ControllerBase {
       $pickup_time->setTime(23, 59, 59);
 
       if ($pickup_time >= $tomorrow) {
+        $user = \Drupal::currentUser();
         if ($patron_id == $cancel_record->patronId || $user->hasRole('staff') || $user->hasRole('administrator')) {
           // go ahead and cancel the record
           $num_deleted = $db->delete('arborcat_patron_pickup_request')

--- a/templates/pickup-helper-theme.html.twig
+++ b/templates/pickup-helper-theme.html.twig
@@ -86,11 +86,13 @@
                 <td>
                     {% set todaysDate = date() | date("U") %}
                     {% set scheduledDate = scheduled.pickupDate|date("U") %}
+                    {# MelCat requests have 10 day expiration period #}
+                    {% set numberOfDaysTillExpire = (scheduled.hold.pickup_lib > 110) ? '+10 days' : '+7 days' %}
                     {# Only enable the cancel button on appointments that are tomorrow or later #}
                     {% if scheduledDate > todaysDate %}
-                      <button class="cancel-pickup button" data-href="{{ base_path }}/cancelpickuprequest/" data-salt="{{ scheduled.hashed_id }}" data-cutoffdate="{{ scheduled.hold.shelf_time|date_modify('+7 days')|date('m-d-Y') }}">Cancel</button>
+                      <button class="cancel-pickup button" data-href="{{ base_path }}/cancelpickuprequest/" data-salt="{{ scheduled.hashed_id }}" data-cutoffdate="{{ scheduled.hold.shelf_time|date_modify(numberOfDaysTillExpire)|date('Y-m-d') }}">Cancel</button>
                     {% else %}
-                      <button class="cancel-pickup button" data-href="{{ base_path }}/cancelpickuprequest/" data-salt="{{ scheduled.hashed_id }}" data-cutoffdate="{{ scheduled.hold.shelf_time|date_modify('+7 days')|date('m-d-Y') }}" disabled>Cancel</button>
+                      <button class="cancel-pickup button" data-href="{{ base_path }}/cancelpickuprequest/" data-salt="{{ scheduled.hashed_id }}" data-cutoffdate="{{ scheduled.hold.shelf_time|date_modify(numberOfDaysTillExpire)|date('Y-m-d') }}" disabled>Cancel</button>
                     {% endif %}
                 </td>
               </tr>


### PR DESCRIPTION
Per Arborcat Isssue #159
Added check for melcat hold request in order to set the default shelf expiry time to 10 days instead of 7 when the 'Cancel' button is clicked in pickupHelper
Changed date format passed in the cancel request to Y-m-d format. Adjusted the aadl front-end to handle that change.