### PR TITLE
Get bib record use harvest during devel

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -33,8 +33,11 @@ class DefaultController extends ControllerBase {
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
     // set the api get record request to use either the api record "full" or "harvest" call depending whether 
     // the api being called is the development/testing version of the api located on pinkeye
-    $get_record_selector = (strpos($api_url, 'pinkeye') !== false) ? 'harvest' : 'full';
+    $use_harvest_option = \Drupal::config('arborcat.settings')->get('api_use_harvest_option_for_bib');
+    dblog('use_harvest_option =', $use_harvest_option);
+    $get_record_selector = ($use_harvest_option == true) ? 'harvest' : 'full';
     $get_url = "$api_url/record/$bnum/$get_record_selector";
+    dblog($get_url);
     // Get Bib Record from API
     $guzzle = \Drupal::httpClient();
     try {

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -32,10 +32,13 @@ class DefaultController extends ControllerBase {
   public function bibrecord_page($bnum) {
     $api_url = \Drupal::config('arborcat.settings')->get('api_url');
 
+    $get_record_selector = (strpos($api_url, 'evgtest') !== false) ? 'harvest' : 'full';
+
     // Get Bib Record from API
     $guzzle = \Drupal::httpClient();
     try {
-      $json = json_decode($guzzle->get("$api_url/record/$bnum/full")->getBody()->getContents());
+
+      $json = json_decode($guzzle->get("$api_url/record/$bnum/$get_record_selector")->getBody()->getContents());
       $bib_record = $json;
       // Copy from Elasticsearch record id to same format as CouchDB _id
       //$bib_record->_id = $bib_record->id;

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -34,10 +34,8 @@ class DefaultController extends ControllerBase {
     // set the api get record request to use either the api record "full" or "harvest" call depending whether 
     // the api being called is the development/testing version of the api located on pinkeye
     $use_harvest_option = \Drupal::config('arborcat.settings')->get('api_use_harvest_option_for_bib');
-    dblog('use_harvest_option =', $use_harvest_option);
     $get_record_selector = ($use_harvest_option == true) ? 'harvest' : 'full';
     $get_url = "$api_url/record/$bnum/$get_record_selector";
-    dblog($get_url);
     // Get Bib Record from API
     $guzzle = \Drupal::httpClient();
     try {

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -38,12 +38,14 @@ class DefaultController extends ControllerBase {
     $get_url = "$api_url/record/$bnum/$get_record_selector";
     // Get Bib Record from API
     $guzzle = \Drupal::httpClient();
+    dblog($get_url);
     try {
       $json = json_decode($guzzle->get($get_url)->getBody()->getContents());
+      dblog('try:' ,$json);
 
       if ($get_record_selector == 'harvest') {
         $bib_record = $json->bib;
-        $bib_record->_id = $json->bnum;
+        $bib_record->_id = $json->_id;
       }
       else {
         $bib_record = $json;
@@ -55,7 +57,9 @@ class DefaultController extends ControllerBase {
       $bib_record->_id = NULL;
     }
 
-    if (!$bib_record->_id) {
+      dblog('bib_record:' ,$bib_record);
+
+      if (!$bib_record->_id) {
       $markup = "<p class=\"base-margin-top\">Sorry, the item you are looking for couldn't be found.</p>";
 
       return [

--- a/src/Form/ArborcatAdminForm.php
+++ b/src/Form/ArborcatAdminForm.php
@@ -47,11 +47,12 @@ class ArborcatAdminForm extends ConfigFormBase {
 
   public function buildForm(array $form, \Drupal\Core\Form\FormStateInterface $form_state) {
     $form = [];
+    $arborcat_settings = \Drupal::config('arborcat.settings');
 
     $form['api_url'] = [
       '#type' => 'textfield',
       '#title' => t('API URL'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('api_url'),
+      '#default_value' => $arborcat_settings->get('api_url'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('URL of the API server for Arborcat. (e.g. https://api.website.org)'),
@@ -60,7 +61,7 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['api_key'] = [
       '#type' => 'textfield',
       '#title' => t('API Auth Key'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('api_key'),
+      '#default_value' => $arborcat_settings->get('api_key'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('API Key for authentication'),
@@ -68,7 +69,7 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['mcb_lockers'] = [
       '#type' => 'textfield',
       '#title' => t('MCB Lockers URL'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('mcb_lockers'),
+      '#default_value' => $arborcat_settings->get('mcb_lockers'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('Lockers URL for checking availability'),
@@ -77,7 +78,7 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['pts_lockers'] = [
       '#type' => 'textfield',
       '#title' => t('PTS Lockers URL'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('pts_lockers'),
+      '#default_value' => $arborcat_settings->get('pts_lockers'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('Lockers URL for checking availability'),
@@ -86,7 +87,7 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['pts_lockers_insert'] = [
       '#type' => 'textfield',
       '#title' => t('PTS Lockers Insert URL'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('pts_lockers_insert'),
+      '#default_value' => $arborcat_settings->get('pts_lockers_insert'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('Lockers URL for adding lockers'),
@@ -95,7 +96,7 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['lockers_pass'] = [
       '#type' => 'textfield',
       '#title' => t('Lockers Interface Password'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('lockers_pass'),
+      '#default_value' => $arborcat_settings->get('lockers_pass'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('Password for accessing lockers interfaces'),
@@ -104,7 +105,7 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['pickup_requests_salt'] = [
       '#type' => 'textfield',
       '#title' => t('Salt for pickup requests'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('pickup_requests_salt'),
+      '#default_value' => $arborcat_settings->get('pickup_requests_salt'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('Salt string for unpacking barcode numbers for pickup requests'),
@@ -113,7 +114,7 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['selfcheck_key'] = [
       '#type' => 'textfield',
       '#title' => t('Self-check key for patron api requests'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('selfcheck_key'),
+      '#default_value' => $arborcat_settings->get('selfcheck_key'),
       '#size' => 32,
       '#maxlength' => 64,
       '#description' => t('self-check key for use with api requests pertaining to the patron data without the need to be signed in'),
@@ -122,22 +123,29 @@ class ArborcatAdminForm extends ConfigFormBase {
     $form['max_locker_items_check'] = [
       '#type' => 'number',
       '#title' => t('Max Number of Items that should fit in a Locker'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('max_locker_items_check'),
+      '#default_value' => $arborcat_settings->get('max_locker_items_check'),
       '#description' => t('If more items that this number are selected for locker pickup, a warning will be displayed to the patron'),
     ];
 
     $form['starting_day_offset'] = [
       '#type' => 'number',
       '#title' => t('Starting Day Offset'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('starting_day_offset'),
+      '#default_value' => $arborcat_settings->get('starting_day_offset'),
       '#description' => t('Number of days from today until the starting day of pickup dates that will be displayed to the user'),
     ];
 
     $form['number_of_pickup_days'] = [
       '#type' => 'number',
       '#title' => t('Number of Pickup Days'),
-      '#default_value' => \Drupal::config('arborcat.settings')->get('number_of_pickup_days'),
+      '#default_value' => $arborcat_settings->get('number_of_pickup_days'),
       '#description' => t('Number of pickup dates that will be displayed to the user'),
+    ];
+
+    $form['api_use_harvest_option_for_bib'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Use Harvest option when requesting bib records using the API'),
+      '#default_value' => $arborcat_settings->get('api_use_harvest_option_for_bib'),
+      '#description' => t('Make bib record api call using  "harvest" option when requesting bib records using the API'),
     ];
 
     return parent::buildForm($form, $form_state);


### PR DESCRIPTION
Added conditional check when performing the bibrecord_page get request to the API.
If the api configuration is set to use pinkeye, the record get request is made with a 'harvest' parameter rather than 'full' parameter