### PR TITLE
fixed exception when a non-existant bib record is attempted to be loaded 

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -45,19 +45,21 @@ class DefaultController extends ControllerBase {
 
     // Get Bib Record from API
     $guzzle = \Drupal::httpClient();
+    $bib_record = (object)[]; 
     try {
-      $json = json_decode($guzzle->get($get_url)->getBody()->getContents());
+      $response_object = json_decode($guzzle->get($get_url)->getBody()->getContents());
       if ($get_record_selector == 'harvest') {
-        $bib_record = $json->bib;
-        $bib_record->_id = $json->_id;
+        $bib_record = $response_object->bib;
+        $bib_record->_id = $response_object->_id;
       }
       else {
-        $bib_record = $json;
+        $bib_record = $response_object;
       }
       // Copy from Elasticsearch record id to same format as CouchDB _id
       //$bib_record->_id = $bib_record->id;
       $bib_record->id = $bib_record->_id;
-    } catch (\Exception $e) {
+    } 
+    catch (\Exception $e) {
       $bib_record->_id = NULL;
     }
 


### PR DESCRIPTION
Exception being thrown:
PHP message: Uncaught PHP Exception Error: "Attempt to assign property "_id" on null at /var/www/drupal10/web/modules/custom/arborcat/src/Controller/DefaultController.php line 61" while reading response header from upstream, client: 10.0.9.41, server: dev.aadl.org, request: "GET /catalog/record/ibib-100059602 HTTP/2.0", upstream: "fastcgi://unix:/var/run/php/php8.1-fpm.sock:", host: "dev.aadl.org"

Passing a non existant bibID causes the exception.  You can observe it on dev and production - here:
http://dev.aadl.org/catalog/record/ibib-100059602
http://aadl.org/catalog/record/ibib-100059602

Fix:
initialized bib_record before the try/catch
to avoid confusion, renamed $json variable to $response_object as json_decode method returns a PHP object. Test bib to load: https://aadl.org/catalog/record/ib-100010008

Tested locally and on dev.